### PR TITLE
Updated Datafusion to Vanilla V38

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,7 +651,8 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "38.0.0"
-source = "git+https://github.com/sdf-labs/arrow-datafusion?branch=zhong/v38#6d9434602044f74511d6454e61f7a4926ce4553f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05fb4eeeb7109393a0739ac5b8fd892f95ccef691421491c85544f7997366f68"
 dependencies = [
  "ahash",
  "arrow",
@@ -702,7 +703,8 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "38.0.0"
-source = "git+https://github.com/sdf-labs/arrow-datafusion?branch=zhong/v38#6d9434602044f74511d6454e61f7a4926ce4553f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "741aeac15c82f239f2fc17deccaab19873abbd62987be20023689b15fa72fa09"
 dependencies = [
  "ahash",
  "arrow",
@@ -722,7 +724,8 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "38.0.0"
-source = "git+https://github.com/sdf-labs/arrow-datafusion?branch=zhong/v38#6d9434602044f74511d6454e61f7a4926ce4553f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e8ddfb8d8cb51646a30da0122ecfffb81ca16919ae9a3495a9e7468bdcd52b8"
 dependencies = [
  "tokio",
 ]
@@ -730,7 +733,8 @@ dependencies = [
 [[package]]
 name = "datafusion-execution"
 version = "38.0.0"
-source = "git+https://github.com/sdf-labs/arrow-datafusion?branch=zhong/v38#6d9434602044f74511d6454e61f7a4926ce4553f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282122f90b20e8f98ebfa101e4bf20e718fd2684cf81bef4e8c6366571c64404"
 dependencies = [
  "arrow",
  "chrono",
@@ -750,7 +754,8 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "38.0.0"
-source = "git+https://github.com/sdf-labs/arrow-datafusion?branch=zhong/v38#6d9434602044f74511d6454e61f7a4926ce4553f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5478588f733df0dfd87a62671c7478f590952c95fa2fa5c137e3ff2929491e22"
 dependencies = [
  "ahash",
  "arrow",
@@ -767,7 +772,8 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "38.0.0"
-source = "git+https://github.com/sdf-labs/arrow-datafusion?branch=zhong/v38#6d9434602044f74511d6454e61f7a4926ce4553f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4afd261cea6ac9c3ca1192fd5e9f940596d8e9208c5b1333f4961405db53185"
 dependencies = [
  "arrow",
  "base64",
@@ -793,7 +799,8 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "38.0.0"
-source = "git+https://github.com/sdf-labs/arrow-datafusion?branch=zhong/v38#6d9434602044f74511d6454e61f7a4926ce4553f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b36a6c4838ab94b5bf8f7a96ce6ce059d805c5d1dcaa6ace49e034eb65cd999"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -808,7 +815,8 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-array"
 version = "38.0.0"
-source = "git+https://github.com/sdf-labs/arrow-datafusion?branch=zhong/v38#6d9434602044f74511d6454e61f7a4926ce4553f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fdd200a6233f48d3362e7ccb784f926f759100e44ae2137a5e2dcb986a59c4"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -827,7 +835,8 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "38.0.0"
-source = "git+https://github.com/sdf-labs/arrow-datafusion?branch=zhong/v38#6d9434602044f74511d6454e61f7a4926ce4553f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54f2820938810e8a2d71228fd6f59f33396aebc5f5f687fcbf14de5aab6a7e1a"
 dependencies = [
  "arrow",
  "async-trait",
@@ -845,7 +854,8 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "38.0.0"
-source = "git+https://github.com/sdf-labs/arrow-datafusion?branch=zhong/v38#6d9434602044f74511d6454e61f7a4926ce4553f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9adf8eb12716f52ddf01e09eb6c94d3c9b291e062c05c91b839a448bddba2ff8"
 dependencies = [
  "ahash",
  "arrow",
@@ -875,7 +885,8 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "38.0.0"
-source = "git+https://github.com/sdf-labs/arrow-datafusion?branch=zhong/v38#6d9434602044f74511d6454e61f7a4926ce4553f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d5472c3230584c150197b3f2c23f2392b9dc54dbfb62ad41e7e36447cfce4be"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -885,7 +896,8 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "38.0.0"
-source = "git+https://github.com/sdf-labs/arrow-datafusion?branch=zhong/v38#6d9434602044f74511d6454e61f7a4926ce4553f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18ae750c38389685a8b62e5b899bbbec488950755ad6d218f3662d35b800c4fe"
 dependencies = [
  "ahash",
  "arrow",
@@ -918,7 +930,8 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "38.0.0"
-source = "git+https://github.com/sdf-labs/arrow-datafusion?branch=zhong/v38#6d9434602044f74511d6454e61f7a4926ce4553f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "befc67a3cdfbfa76853f43b10ac27337821bb98e519ab6baf431fcc0bcfcafdb"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -1878,20 +1891,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "sdf-functions"
-version = "0.1.0"
-dependencies = [
- "arrow",
- "chrono",
- "chrono-tz 0.5.3",
- "datafusion",
- "log",
- "regex",
- "rust-embed",
- "tokio",
-]
-
-[[package]]
 name = "semver"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1993,6 +1992,20 @@ name = "snap"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
+
+[[package]]
+name = "sql-functions"
+version = "0.1.0"
+dependencies = [
+ "arrow",
+ "chrono",
+ "chrono-tz 0.5.3",
+ "datafusion",
+ "log",
+ "regex",
+ "rust-embed",
+ "tokio",
+]
 
 [[package]]
 name = "sqlparser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,14 +16,14 @@
 # under the License.
 
 [package]
-name = "sdf-functions"
+name = "sql-functions"
 version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [lib]
-name = "sdf_functions"
+name = "sql_functions"
 path = "src/lib.rs"
 
 [features]
@@ -33,7 +33,7 @@ default = ["presto_expressions"]
 presto_expressions = []
 
 [dependencies]
-datafusion = { git = "https://github.com/sdf-labs/arrow-datafusion", branch = "zhong/v38" }
+datafusion = { version = "38"}
 arrow = { version = "51.0.0", features = ["prettyprint"] }
 #arrow-flight = { workspace = true }
 #arrow-schema = { workspace = true }

--- a/README.md
+++ b/README.md
@@ -30,5 +30,6 @@ The functions in this crate are *monomorphic* by default. This means that each f
 This is in contrast to polymorphic functions, which can operate on multiple types through mechanisms such as generics or type parameters. Monomorphic functions are typically simpler in terms of type checking and type inference, as there are no generic type parameters to resolve.
 
 ## Contributing
+Contributions are more than welcome! Both to the list of reports, or documentation. Please carefully read [CONTRIBUTING.md](CONTRIBUTING.md)
 
-## 
+## Using SQL Functions Crate

--- a/contributing.md
+++ b/contributing.md
@@ -27,6 +27,13 @@ function:
   variadic: [any, uniform, non-uniform, even-odd]
 ```
 
-
 ## Contributing a function Implementation
-*todo*
+To contribute a function implementation, fill in the `todo!()` block of a given function.
+
+``` rust
+fn invoke(&self, args: &[ColumnarValue]) -> Result<ColumnarValue> {
+        // start function impl
+        todo!()
+        // end function impl
+    }
+```


### PR DESCRIPTION
To publish crate, we need to use a versioned release of all dependencies. Publishing a crate is blocked with:
```
sdf-functions % cargo publish --dry-run
    Blocking waiting for file lock on package cache
    Updating crates.io index
error: all dependencies must have a version specified when publishing.
dependency `datafusion` does not specify a version
Note: The published dependency will use the version from crates.io,
the `git` specification will be removed from the dependency declaration.
```

This change switches use to default datafusion.