### PR TITLE
Corrections for implemented-by: !datafusion.

### DIFF
--- a/assets/presto/functions.sdf.yml
+++ b/assets/presto/functions.sdf.yml
@@ -3353,6 +3353,7 @@ function:
   returns:
     datatype: $5
 ---
+# DF md5 returns a varchar, but Trino returns a varbinary.
 function:
   name: md5
   parameters:
@@ -3360,7 +3361,6 @@ function:
   optional-parameters: []
   returns:
     datatype: varbinary
-  implemented-by: !datafusion
 ---
 function:
   name: merge

--- a/assets/presto/functions_extra.sdf.yml
+++ b/assets/presto/functions_extra.sdf.yml
@@ -80,6 +80,36 @@ function:
   volatility: stable
 ---
 function:
+  name: date_part
+  parameters:
+  - datatype: varchar
+  - datatype: time(p)
+  optional-parameters: []
+  returns:
+    datatype: double
+  implemented-by: !datafusion
+---
+function:
+  name: date_part
+  parameters:
+  - datatype: varchar
+  - datatype: timestamp(p)
+  optional-parameters: []
+  returns:
+    datatype: double
+  implemented-by: !datafusion
+---
+function:
+  name: date_part
+  parameters:
+  - datatype: varchar
+  - datatype: date
+  optional-parameters: []
+  returns:
+    datatype: double
+  implemented-by: !datafusion
+---
+function:
   name: localtime
   kind: scalar
   parameters: []


### PR DESCRIPTION
Based on testing in sdf
- Put back date_part, because there are many tests using it.
- Take out md5, because Trino and DF return types are different (varbinary vs varchar).