### PR TITLE
Fill the gaps in the date_part family of functions. 

### DIFF
--- a/assets/trino/functions.sdf.yml
+++ b/assets/trino/functions.sdf.yml
@@ -2445,6 +2445,7 @@ function:
   optional-parameters: []
   returns:
     datatype: bigint
+  implemented-by: !rust
   section: datetime
   cross-link: https://trino.io/docs/current/functions/datetime.html#day
   description: >
@@ -2457,6 +2458,7 @@ function:
   optional-parameters: []
   returns:
     datatype: bigint
+  implemented-by: !rust
   section: datetime
   cross-link: https://trino.io/docs/current/functions/datetime.html#day_of_month
   description: >
@@ -2481,6 +2483,7 @@ function:
   optional-parameters: []
   returns:
     datatype: bigint
+  implemented-by: !rust
   section: datetime
   cross-link: https://trino.io/docs/current/functions/datetime.html#day_of_month
   description: >
@@ -2493,6 +2496,7 @@ function:
   optional-parameters: []
   returns:
     datatype: bigint
+  implemented-by: !rust
   section: datetime
   cross-link: https://trino.io/docs/current/functions/datetime.html#day_of_week
   description: >
@@ -2506,6 +2510,7 @@ function:
   optional-parameters: []
   returns:
     datatype: bigint
+  implemented-by: !rust
   section: datetime
   cross-link: https://trino.io/docs/current/functions/datetime.html#day_of_week
   description: >
@@ -2519,6 +2524,7 @@ function:
   optional-parameters: []
   returns:
     datatype: bigint
+  implemented-by: !rust
   section: datetime
   cross-link: https://trino.io/docs/current/functions/datetime.html#day_of_year
   description: >
@@ -2532,6 +2538,7 @@ function:
   optional-parameters: []
   returns:
     datatype: bigint
+  implemented-by: !rust
   section: datetime
   cross-link: https://trino.io/docs/current/functions/datetime.html#day_of_year
   description: >
@@ -2572,6 +2579,7 @@ function:
   optional-parameters: []
   returns:
     datatype: bigint
+  implemented-by: !rust
   section: datetime
   cross-link: https://trino.io/docs/current/functions/datetime.html#dow
   description: >
@@ -2584,6 +2592,7 @@ function:
   optional-parameters: []
   returns:
     datatype: bigint
+  implemented-by: !rust
   section: datetime
   cross-link: https://trino.io/docs/current/functions/datetime.html#dow
   description: >
@@ -2596,6 +2605,7 @@ function:
   optional-parameters: []
   returns:
     datatype: bigint
+  implemented-by: !rust
   section: datetime
   cross-link: https://trino.io/docs/current/functions/datetime.html#doy
   description: >
@@ -2608,6 +2618,7 @@ function:
   optional-parameters: []
   returns:
     datatype: bigint
+  implemented-by: !rust
   section: datetime
   cross-link: https://trino.io/docs/current/functions/datetime.html#doy
   description: >
@@ -3684,6 +3695,7 @@ function:
   optional-parameters: []
   returns:
     datatype: bigint
+  implemented-by: !rust
   section: datetime
   cross-link: https://trino.io/docs/current/functions/datetime.html#hour
   description: >
@@ -3697,6 +3709,7 @@ function:
   optional-parameters: []
   returns:
     datatype: bigint
+  implemented-by: !rust
   section: datetime
   cross-link: https://trino.io/docs/current/functions/datetime.html#hour
   description: >
@@ -5100,6 +5113,7 @@ function:
   optional-parameters: []
   returns:
     datatype: bigint
+  implemented-by: !rust
   section: datetime
   cross-link: https://trino.io/docs/current/functions/datetime.html#millisecond
   description: >
@@ -5112,6 +5126,7 @@ function:
   optional-parameters: []
   returns:
     datatype: bigint
+  implemented-by: !rust
   section: datetime
   cross-link: https://trino.io/docs/current/functions/datetime.html#millisecond
   description: >
@@ -5199,6 +5214,7 @@ function:
   optional-parameters: []
   returns:
     datatype: bigint
+  implemented-by: !rust
   section: datetime
   cross-link: https://trino.io/docs/current/functions/datetime.html#minute
   description: >
@@ -5211,6 +5227,7 @@ function:
   optional-parameters: []
   returns:
     datatype: bigint
+  implemented-by: !rust
   section: datetime
   cross-link: https://trino.io/docs/current/functions/datetime.html#minute
   description: >
@@ -5339,6 +5356,7 @@ function:
   optional-parameters: []
   returns:
     datatype: bigint
+  implemented-by: !rust
   section: datetime
   cross-link: https://trino.io/docs/current/functions/datetime.html#month
   description: >
@@ -6973,6 +6991,7 @@ function:
   optional-parameters: []
   returns:
     datatype: bigint
+  implemented-by: !rust
   section: datetime
   cross-link: https://trino.io/docs/current/functions/datetime.html#second
   description: >
@@ -6985,6 +7004,7 @@ function:
   optional-parameters: []
   returns:
     datatype: bigint
+  implemented-by: !rust
   section: datetime
   cross-link: https://trino.io/docs/current/functions/datetime.html#second
   description: >
@@ -9677,6 +9697,7 @@ function:
   optional-parameters: []
   returns:
     datatype: bigint
+  implemented-by: !rust
   section: datetime
   cross-link: https://trino.io/docs/current/functions/datetime.html#year
   description: >

--- a/src/trino/day_impl.rs
+++ b/src/trino/day_impl.rs
@@ -25,7 +25,7 @@ use datafusion::logical_expr::simplify::{ExprSimplifyResult, SimplifyInfo};
 use datafusion::logical_expr::{ColumnarValue, Expr, ScalarUDFImpl, Signature, Volatility};
 use std::any::Any;
 
-use crate::utils::make_scalar_function;
+use crate::utils::{apply_datepart_kernel, make_scalar_function};
 
 fn day_date_invoke(args: &[ColumnarValue]) -> Result<ColumnarValue> {
     make_scalar_function(day, vec![])(args)
@@ -62,12 +62,12 @@ fn day_intervaldaytosecond_simplify(
     Ok(ExprSimplifyResult::Original(args))
 }
 
-fn day_timestamp_p_invoke(_args: &[ColumnarValue]) -> Result<ColumnarValue> {
-    Err(DataFusionError::NotImplemented("todo".to_string()))
+fn day_timestamp_p_invoke(args: &[ColumnarValue]) -> Result<ColumnarValue> {
+    apply_datepart_kernel(&args[0], DatePart::Day)
 }
 
 fn day_timestamp_p_return_type(_arg_types: &[DataType]) -> Result<DataType> {
-    Err(DataFusionError::NotImplemented("todo".to_string()))
+    Ok(DataType::Int64)
 }
 
 fn day_timestamp_p_simplify(

--- a/src/trino/day_impl.rs
+++ b/src/trino/day_impl.rs
@@ -16,8 +16,7 @@
 // under the License.
 
 #![allow(non_camel_case_types)]
-use arrow::array::ArrayRef;
-use arrow::compute::{cast, date_part, DatePart};
+use arrow::compute::DatePart;
 use arrow::datatypes::DataType;
 use datafusion::common::Result;
 use datafusion::error::DataFusionError;
@@ -25,18 +24,10 @@ use datafusion::logical_expr::simplify::{ExprSimplifyResult, SimplifyInfo};
 use datafusion::logical_expr::{ColumnarValue, Expr, ScalarUDFImpl, Signature, Volatility};
 use std::any::Any;
 
-use crate::utils::{apply_datepart_kernel, make_scalar_function};
+use crate::utils::apply_datepart_kernel;
 
 fn day_date_invoke(args: &[ColumnarValue]) -> Result<ColumnarValue> {
-    make_scalar_function(day, vec![])(args)
-}
-
-fn day(args: &[ArrayRef]) -> Result<ArrayRef> {
-    let array = &args[0];
-    Ok(cast(
-        date_part(array, DatePart::Day)?.as_ref(),
-        &DataType::Int64,
-    )?)
+    apply_datepart_kernel(&args[0], DatePart::Day)
 }
 
 fn day_date_return_type(_arg_types: &[DataType]) -> Result<DataType> {

--- a/src/trino/day_of_month_impl.rs
+++ b/src/trino/day_of_month_impl.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 #![allow(non_camel_case_types)]
+use arrow::compute::DatePart;
 use arrow::datatypes::DataType;
 use datafusion::common::Result;
 use datafusion::error::DataFusionError;
@@ -23,20 +24,14 @@ use datafusion::logical_expr::simplify::{ExprSimplifyResult, SimplifyInfo};
 use datafusion::logical_expr::{ColumnarValue, Expr, ScalarUDFImpl, Signature, Volatility};
 use std::any::Any;
 
-fn day_of_month_date_invoke(_args: &[ColumnarValue]) -> Result<ColumnarValue> {
-    Err(DataFusionError::NotImplemented(format!(
-        "Not implemented {}:{}",
-        file!(),
-        line!()
-    )))
+use crate::utils::apply_datepart_kernel;
+
+fn day_of_month_date_invoke(args: &[ColumnarValue]) -> Result<ColumnarValue> {
+    apply_datepart_kernel(&args[0], DatePart::Day)
 }
 
 fn day_of_month_date_return_type(_arg_types: &[DataType]) -> Result<DataType> {
-    Err(DataFusionError::NotImplemented(format!(
-        "Not implemented {}:{}",
-        file!(),
-        line!()
-    )))
+    Ok(DataType::Int64)
 }
 
 fn day_of_month_date_simplify(
@@ -69,20 +64,12 @@ fn day_of_month_intervaldaytosecond_simplify(
     Ok(ExprSimplifyResult::Original(args))
 }
 
-fn day_of_month_timestamp_p_invoke(_args: &[ColumnarValue]) -> Result<ColumnarValue> {
-    Err(DataFusionError::NotImplemented(format!(
-        "Not implemented {}:{}",
-        file!(),
-        line!()
-    )))
+fn day_of_month_timestamp_p_invoke(args: &[ColumnarValue]) -> Result<ColumnarValue> {
+    apply_datepart_kernel(&args[0], DatePart::Day)
 }
 
 fn day_of_month_timestamp_p_return_type(_arg_types: &[DataType]) -> Result<DataType> {
-    Err(DataFusionError::NotImplemented(format!(
-        "Not implemented {}:{}",
-        file!(),
-        line!()
-    )))
+    Ok(DataType::Int64)
 }
 
 fn day_of_month_timestamp_p_simplify(

--- a/src/trino/day_of_week_impl.rs
+++ b/src/trino/day_of_week_impl.rs
@@ -18,25 +18,18 @@
 #![allow(non_camel_case_types)]
 use arrow::datatypes::DataType;
 use datafusion::common::Result;
-use datafusion::error::DataFusionError;
 use datafusion::logical_expr::simplify::{ExprSimplifyResult, SimplifyInfo};
 use datafusion::logical_expr::{ColumnarValue, Expr, ScalarUDFImpl, Signature, Volatility};
 use std::any::Any;
 
-fn day_of_week_date_invoke(_args: &[ColumnarValue]) -> Result<ColumnarValue> {
-    Err(DataFusionError::NotImplemented(format!(
-        "Not implemented {}:{}",
-        file!(),
-        line!()
-    )))
+use crate::utils::apply_dow_kernel;
+
+fn day_of_week_date_invoke(args: &[ColumnarValue]) -> Result<ColumnarValue> {
+    apply_dow_kernel(&args[0])
 }
 
 fn day_of_week_date_return_type(_arg_types: &[DataType]) -> Result<DataType> {
-    Err(DataFusionError::NotImplemented(format!(
-        "Not implemented {}:{}",
-        file!(),
-        line!()
-    )))
+    Ok(DataType::Int64)
 }
 
 fn day_of_week_date_simplify(
@@ -46,20 +39,12 @@ fn day_of_week_date_simplify(
     Ok(ExprSimplifyResult::Original(args))
 }
 
-fn day_of_week_timestamp_p_invoke(_args: &[ColumnarValue]) -> Result<ColumnarValue> {
-    Err(DataFusionError::NotImplemented(format!(
-        "Not implemented {}:{}",
-        file!(),
-        line!()
-    )))
+fn day_of_week_timestamp_p_invoke(args: &[ColumnarValue]) -> Result<ColumnarValue> {
+    apply_dow_kernel(&args[0])
 }
 
 fn day_of_week_timestamp_p_return_type(_arg_types: &[DataType]) -> Result<DataType> {
-    Err(DataFusionError::NotImplemented(format!(
-        "Not implemented {}:{}",
-        file!(),
-        line!()
-    )))
+    Ok(DataType::Int64)
 }
 
 fn day_of_week_timestamp_p_simplify(

--- a/src/trino/day_of_year_impl.rs
+++ b/src/trino/day_of_year_impl.rs
@@ -16,27 +16,21 @@
 // under the License.
 
 #![allow(non_camel_case_types)]
+use arrow::compute::DatePart;
 use arrow::datatypes::DataType;
 use datafusion::common::Result;
-use datafusion::error::DataFusionError;
 use datafusion::logical_expr::simplify::{ExprSimplifyResult, SimplifyInfo};
 use datafusion::logical_expr::{ColumnarValue, Expr, ScalarUDFImpl, Signature, Volatility};
 use std::any::Any;
 
-fn day_of_year_date_invoke(_args: &[ColumnarValue]) -> Result<ColumnarValue> {
-    Err(DataFusionError::NotImplemented(format!(
-        "Not implemented {}:{}",
-        file!(),
-        line!()
-    )))
+use crate::utils::apply_datepart_kernel;
+
+fn day_of_year_date_invoke(args: &[ColumnarValue]) -> Result<ColumnarValue> {
+    apply_datepart_kernel(&args[0], DatePart::DayOfYear)
 }
 
 fn day_of_year_date_return_type(_arg_types: &[DataType]) -> Result<DataType> {
-    Err(DataFusionError::NotImplemented(format!(
-        "Not implemented {}:{}",
-        file!(),
-        line!()
-    )))
+    Ok(DataType::Int64)
 }
 
 fn day_of_year_date_simplify(
@@ -46,20 +40,12 @@ fn day_of_year_date_simplify(
     Ok(ExprSimplifyResult::Original(args))
 }
 
-fn day_of_year_timestamp_p_invoke(_args: &[ColumnarValue]) -> Result<ColumnarValue> {
-    Err(DataFusionError::NotImplemented(format!(
-        "Not implemented {}:{}",
-        file!(),
-        line!()
-    )))
+fn day_of_year_timestamp_p_invoke(args: &[ColumnarValue]) -> Result<ColumnarValue> {
+    apply_datepart_kernel(&args[0], DatePart::DayOfYear)
 }
 
 fn day_of_year_timestamp_p_return_type(_arg_types: &[DataType]) -> Result<DataType> {
-    Err(DataFusionError::NotImplemented(format!(
-        "Not implemented {}:{}",
-        file!(),
-        line!()
-    )))
+    Ok(DataType::Int64)
 }
 
 fn day_of_year_timestamp_p_simplify(

--- a/src/trino/dow_impl.rs
+++ b/src/trino/dow_impl.rs
@@ -18,45 +18,30 @@
 #![allow(non_camel_case_types)]
 use arrow::datatypes::DataType;
 use datafusion::common::Result;
-use datafusion::error::DataFusionError;
 use datafusion::logical_expr::simplify::{ExprSimplifyResult, SimplifyInfo};
 use datafusion::logical_expr::{ColumnarValue, Expr, ScalarUDFImpl, Signature, Volatility};
 use std::any::Any;
 
-fn dow_date_invoke(_args: &[ColumnarValue]) -> Result<ColumnarValue> {
-    Err(DataFusionError::NotImplemented(format!(
-        "Not implemented {}:{}",
-        file!(),
-        line!()
-    )))
+use crate::utils::apply_dow_kernel;
+
+fn dow_date_invoke(args: &[ColumnarValue]) -> Result<ColumnarValue> {
+    apply_dow_kernel(&args[0])
 }
 
 fn dow_date_return_type(_arg_types: &[DataType]) -> Result<DataType> {
-    Err(DataFusionError::NotImplemented(format!(
-        "Not implemented {}:{}",
-        file!(),
-        line!()
-    )))
+    Ok(DataType::Int64)
 }
 
 fn dow_date_simplify(args: Vec<Expr>, _info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
     Ok(ExprSimplifyResult::Original(args))
 }
 
-fn dow_timestamp_p_invoke(_args: &[ColumnarValue]) -> Result<ColumnarValue> {
-    Err(DataFusionError::NotImplemented(format!(
-        "Not implemented {}:{}",
-        file!(),
-        line!()
-    )))
+fn dow_timestamp_p_invoke(args: &[ColumnarValue]) -> Result<ColumnarValue> {
+    apply_dow_kernel(&args[0])
 }
 
 fn dow_timestamp_p_return_type(_arg_types: &[DataType]) -> Result<DataType> {
-    Err(DataFusionError::NotImplemented(format!(
-        "Not implemented {}:{}",
-        file!(),
-        line!()
-    )))
+    Ok(DataType::Int64)
 }
 
 fn dow_timestamp_p_simplify(

--- a/src/trino/doy_impl.rs
+++ b/src/trino/doy_impl.rs
@@ -16,47 +16,33 @@
 // under the License.
 
 #![allow(non_camel_case_types)]
+use arrow::compute::DatePart;
 use arrow::datatypes::DataType;
 use datafusion::common::Result;
-use datafusion::error::DataFusionError;
 use datafusion::logical_expr::simplify::{ExprSimplifyResult, SimplifyInfo};
 use datafusion::logical_expr::{ColumnarValue, Expr, ScalarUDFImpl, Signature, Volatility};
 use std::any::Any;
 
-fn doy_date_invoke(_args: &[ColumnarValue]) -> Result<ColumnarValue> {
-    Err(DataFusionError::NotImplemented(format!(
-        "Not implemented {}:{}",
-        file!(),
-        line!()
-    )))
+use crate::utils::apply_datepart_kernel;
+
+fn doy_date_invoke(args: &[ColumnarValue]) -> Result<ColumnarValue> {
+    apply_datepart_kernel(&args[0], DatePart::DayOfYear)
 }
 
 fn doy_date_return_type(_arg_types: &[DataType]) -> Result<DataType> {
-    Err(DataFusionError::NotImplemented(format!(
-        "Not implemented {}:{}",
-        file!(),
-        line!()
-    )))
+    Ok(DataType::Int64)
 }
 
 fn doy_date_simplify(args: Vec<Expr>, _info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
     Ok(ExprSimplifyResult::Original(args))
 }
 
-fn doy_timestamp_p_invoke(_args: &[ColumnarValue]) -> Result<ColumnarValue> {
-    Err(DataFusionError::NotImplemented(format!(
-        "Not implemented {}:{}",
-        file!(),
-        line!()
-    )))
+fn doy_timestamp_p_invoke(args: &[ColumnarValue]) -> Result<ColumnarValue> {
+    apply_datepart_kernel(&args[0], DatePart::DayOfYear)
 }
 
 fn doy_timestamp_p_return_type(_arg_types: &[DataType]) -> Result<DataType> {
-    Err(DataFusionError::NotImplemented(format!(
-        "Not implemented {}:{}",
-        file!(),
-        line!()
-    )))
+    Ok(DataType::Int64)
 }
 
 fn doy_timestamp_p_simplify(

--- a/src/trino/hour_impl.rs
+++ b/src/trino/hour_impl.rs
@@ -16,12 +16,15 @@
 // under the License.
 
 #![allow(non_camel_case_types)]
+use arrow::compute::DatePart;
 use arrow::datatypes::DataType;
 use datafusion::common::Result;
 use datafusion::error::DataFusionError;
 use datafusion::logical_expr::simplify::{ExprSimplifyResult, SimplifyInfo};
 use datafusion::logical_expr::{ColumnarValue, Expr, ScalarUDFImpl, Signature, Volatility};
 use std::any::Any;
+
+use crate::utils::apply_datepart_kernel;
 
 fn hour_intervaldaytosecond_invoke(_args: &[ColumnarValue]) -> Result<ColumnarValue> {
     Err(DataFusionError::NotImplemented(format!(
@@ -46,40 +49,24 @@ fn hour_intervaldaytosecond_simplify(
     Ok(ExprSimplifyResult::Original(args))
 }
 
-fn hour_time_p_invoke(_args: &[ColumnarValue]) -> Result<ColumnarValue> {
-    Err(DataFusionError::NotImplemented(format!(
-        "Not implemented {}:{}",
-        file!(),
-        line!()
-    )))
+fn hour_time_p_invoke(args: &[ColumnarValue]) -> Result<ColumnarValue> {
+    apply_datepart_kernel(&args[0], DatePart::Hour)
 }
 
 fn hour_time_p_return_type(_arg_types: &[DataType]) -> Result<DataType> {
-    Err(DataFusionError::NotImplemented(format!(
-        "Not implemented {}:{}",
-        file!(),
-        line!()
-    )))
+    Ok(DataType::Int64)
 }
 
 fn hour_time_p_simplify(args: Vec<Expr>, _info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
     Ok(ExprSimplifyResult::Original(args))
 }
 
-fn hour_timestamp_p_invoke(_args: &[ColumnarValue]) -> Result<ColumnarValue> {
-    Err(DataFusionError::NotImplemented(format!(
-        "Not implemented {}:{}",
-        file!(),
-        line!()
-    )))
+fn hour_timestamp_p_invoke(args: &[ColumnarValue]) -> Result<ColumnarValue> {
+    apply_datepart_kernel(&args[0], DatePart::Hour)
 }
 
 fn hour_timestamp_p_return_type(_arg_types: &[DataType]) -> Result<DataType> {
-    Err(DataFusionError::NotImplemented(format!(
-        "Not implemented {}:{}",
-        file!(),
-        line!()
-    )))
+    Ok(DataType::Int64)
 }
 
 fn hour_timestamp_p_simplify(

--- a/src/trino/millisecond_impl.rs
+++ b/src/trino/millisecond_impl.rs
@@ -16,12 +16,15 @@
 // under the License.
 
 #![allow(non_camel_case_types)]
+use arrow::compute::DatePart;
 use arrow::datatypes::DataType;
 use datafusion::common::Result;
 use datafusion::error::DataFusionError;
 use datafusion::logical_expr::simplify::{ExprSimplifyResult, SimplifyInfo};
 use datafusion::logical_expr::{ColumnarValue, Expr, ScalarUDFImpl, Signature, Volatility};
 use std::any::Any;
+
+use crate::utils::apply_datepart_kernel;
 
 fn millisecond_intervaldaytosecond_invoke(_args: &[ColumnarValue]) -> Result<ColumnarValue> {
     Err(DataFusionError::NotImplemented(format!(
@@ -46,20 +49,12 @@ fn millisecond_intervaldaytosecond_simplify(
     Ok(ExprSimplifyResult::Original(args))
 }
 
-fn millisecond_time_p_invoke(_args: &[ColumnarValue]) -> Result<ColumnarValue> {
-    Err(DataFusionError::NotImplemented(format!(
-        "Not implemented {}:{}",
-        file!(),
-        line!()
-    )))
+fn millisecond_time_p_invoke(args: &[ColumnarValue]) -> Result<ColumnarValue> {
+    apply_datepart_kernel(&args[0], DatePart::Millisecond)
 }
 
 fn millisecond_time_p_return_type(_arg_types: &[DataType]) -> Result<DataType> {
-    Err(DataFusionError::NotImplemented(format!(
-        "Not implemented {}:{}",
-        file!(),
-        line!()
-    )))
+    Ok(DataType::Int64)
 }
 
 fn millisecond_time_p_simplify(
@@ -69,20 +64,12 @@ fn millisecond_time_p_simplify(
     Ok(ExprSimplifyResult::Original(args))
 }
 
-fn millisecond_timestamp_p_invoke(_args: &[ColumnarValue]) -> Result<ColumnarValue> {
-    Err(DataFusionError::NotImplemented(format!(
-        "Not implemented {}:{}",
-        file!(),
-        line!()
-    )))
+fn millisecond_timestamp_p_invoke(args: &[ColumnarValue]) -> Result<ColumnarValue> {
+    apply_datepart_kernel(&args[0], DatePart::Millisecond)
 }
 
 fn millisecond_timestamp_p_return_type(_arg_types: &[DataType]) -> Result<DataType> {
-    Err(DataFusionError::NotImplemented(format!(
-        "Not implemented {}:{}",
-        file!(),
-        line!()
-    )))
+    Ok(DataType::Int64)
 }
 
 fn millisecond_timestamp_p_simplify(

--- a/src/trino/minute_impl.rs
+++ b/src/trino/minute_impl.rs
@@ -16,12 +16,15 @@
 // under the License.
 
 #![allow(non_camel_case_types)]
+use arrow::compute::DatePart;
 use arrow::datatypes::DataType;
 use datafusion::common::Result;
 use datafusion::error::DataFusionError;
 use datafusion::logical_expr::simplify::{ExprSimplifyResult, SimplifyInfo};
 use datafusion::logical_expr::{ColumnarValue, Expr, ScalarUDFImpl, Signature, Volatility};
 use std::any::Any;
+
+use crate::utils::apply_datepart_kernel;
 
 fn minute_intervaldaytosecond_invoke(_args: &[ColumnarValue]) -> Result<ColumnarValue> {
     Err(DataFusionError::NotImplemented(format!(
@@ -46,40 +49,24 @@ fn minute_intervaldaytosecond_simplify(
     Ok(ExprSimplifyResult::Original(args))
 }
 
-fn minute_time_p_invoke(_args: &[ColumnarValue]) -> Result<ColumnarValue> {
-    Err(DataFusionError::NotImplemented(format!(
-        "Not implemented {}:{}",
-        file!(),
-        line!()
-    )))
+fn minute_time_p_invoke(args: &[ColumnarValue]) -> Result<ColumnarValue> {
+    apply_datepart_kernel(&args[0], DatePart::Minute)
 }
 
 fn minute_time_p_return_type(_arg_types: &[DataType]) -> Result<DataType> {
-    Err(DataFusionError::NotImplemented(format!(
-        "Not implemented {}:{}",
-        file!(),
-        line!()
-    )))
+    Ok(DataType::Int64)
 }
 
 fn minute_time_p_simplify(args: Vec<Expr>, _info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
     Ok(ExprSimplifyResult::Original(args))
 }
 
-fn minute_timestamp_p_invoke(_args: &[ColumnarValue]) -> Result<ColumnarValue> {
-    Err(DataFusionError::NotImplemented(format!(
-        "Not implemented {}:{}",
-        file!(),
-        line!()
-    )))
+fn minute_timestamp_p_invoke(args: &[ColumnarValue]) -> Result<ColumnarValue> {
+    apply_datepart_kernel(&args[0], DatePart::Minute)
 }
 
 fn minute_timestamp_p_return_type(_arg_types: &[DataType]) -> Result<DataType> {
-    Err(DataFusionError::NotImplemented(format!(
-        "Not implemented {}:{}",
-        file!(),
-        line!()
-    )))
+    Ok(DataType::Int64)
 }
 
 fn minute_timestamp_p_simplify(

--- a/src/trino/month_impl.rs
+++ b/src/trino/month_impl.rs
@@ -16,8 +16,7 @@
 // under the License.
 
 #![allow(non_camel_case_types)]
-use arrow::array::ArrayRef;
-use arrow::compute::{cast, date_part, DatePart};
+use arrow::compute::DatePart;
 use arrow::datatypes::DataType;
 use datafusion::common::Result;
 use datafusion::error::DataFusionError;
@@ -25,18 +24,10 @@ use datafusion::logical_expr::simplify::{ExprSimplifyResult, SimplifyInfo};
 use datafusion::logical_expr::{ColumnarValue, Expr, ScalarUDFImpl, Signature, Volatility};
 use std::any::Any;
 
-use crate::utils::{apply_datepart_kernel, make_scalar_function};
+use crate::utils::apply_datepart_kernel;
 
 fn month_date_invoke(args: &[ColumnarValue]) -> Result<ColumnarValue> {
-    make_scalar_function(month, vec![])(args)
-}
-
-fn month(args: &[ArrayRef]) -> Result<ArrayRef> {
-    let array = &args[0];
-    Ok(cast(
-        date_part(array, DatePart::Month)?.as_ref(),
-        &DataType::Int64,
-    )?)
+    apply_datepart_kernel(&args[0], DatePart::Month)
 }
 
 fn month_date_return_type(_arg_types: &[DataType]) -> Result<DataType> {

--- a/src/trino/month_impl.rs
+++ b/src/trino/month_impl.rs
@@ -25,7 +25,7 @@ use datafusion::logical_expr::simplify::{ExprSimplifyResult, SimplifyInfo};
 use datafusion::logical_expr::{ColumnarValue, Expr, ScalarUDFImpl, Signature, Volatility};
 use std::any::Any;
 
-use crate::utils::make_scalar_function;
+use crate::utils::{apply_datepart_kernel, make_scalar_function};
 
 fn month_date_invoke(args: &[ColumnarValue]) -> Result<ColumnarValue> {
     make_scalar_function(month, vec![])(args)
@@ -62,12 +62,12 @@ fn month_intervalyeartomonth_simplify(
     Ok(ExprSimplifyResult::Original(args))
 }
 
-fn month_timestamp_p_invoke(_args: &[ColumnarValue]) -> Result<ColumnarValue> {
-    Err(DataFusionError::NotImplemented("todo".to_string()))
+fn month_timestamp_p_invoke(args: &[ColumnarValue]) -> Result<ColumnarValue> {
+    apply_datepart_kernel(&args[0], DatePart::Month)
 }
 
 fn month_timestamp_p_return_type(_arg_types: &[DataType]) -> Result<DataType> {
-    Err(DataFusionError::NotImplemented("todo".to_string()))
+    Ok(DataType::Int64)
 }
 
 fn month_timestamp_p_simplify(

--- a/src/trino/second_impl.rs
+++ b/src/trino/second_impl.rs
@@ -16,12 +16,15 @@
 // under the License.
 
 #![allow(non_camel_case_types)]
+use arrow::compute::DatePart;
 use arrow::datatypes::DataType;
 use datafusion::common::Result;
 use datafusion::error::DataFusionError;
 use datafusion::logical_expr::simplify::{ExprSimplifyResult, SimplifyInfo};
 use datafusion::logical_expr::{ColumnarValue, Expr, ScalarUDFImpl, Signature, Volatility};
 use std::any::Any;
+
+use crate::utils::apply_datepart_kernel;
 
 fn second_intervaldaytosecond_invoke(_args: &[ColumnarValue]) -> Result<ColumnarValue> {
     Err(DataFusionError::NotImplemented(format!(
@@ -46,40 +49,24 @@ fn second_intervaldaytosecond_simplify(
     Ok(ExprSimplifyResult::Original(args))
 }
 
-fn second_time_p_invoke(_args: &[ColumnarValue]) -> Result<ColumnarValue> {
-    Err(DataFusionError::NotImplemented(format!(
-        "Not implemented {}:{}",
-        file!(),
-        line!()
-    )))
+fn second_time_p_invoke(args: &[ColumnarValue]) -> Result<ColumnarValue> {
+    apply_datepart_kernel(&args[0], DatePart::Second)
 }
 
 fn second_time_p_return_type(_arg_types: &[DataType]) -> Result<DataType> {
-    Err(DataFusionError::NotImplemented(format!(
-        "Not implemented {}:{}",
-        file!(),
-        line!()
-    )))
+    Ok(DataType::Int64)
 }
 
 fn second_time_p_simplify(args: Vec<Expr>, _info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
     Ok(ExprSimplifyResult::Original(args))
 }
 
-fn second_timestamp_p_invoke(_args: &[ColumnarValue]) -> Result<ColumnarValue> {
-    Err(DataFusionError::NotImplemented(format!(
-        "Not implemented {}:{}",
-        file!(),
-        line!()
-    )))
+fn second_timestamp_p_invoke(args: &[ColumnarValue]) -> Result<ColumnarValue> {
+    apply_datepart_kernel(&args[0], DatePart::Second)
 }
 
 fn second_timestamp_p_return_type(_arg_types: &[DataType]) -> Result<DataType> {
-    Err(DataFusionError::NotImplemented(format!(
-        "Not implemented {}:{}",
-        file!(),
-        line!()
-    )))
+    Ok(DataType::Int64)
 }
 
 fn second_timestamp_p_simplify(

--- a/src/trino/year_impl.rs
+++ b/src/trino/year_impl.rs
@@ -16,8 +16,7 @@
 // under the License.
 
 #![allow(non_camel_case_types)]
-use arrow::array::ArrayRef;
-use arrow::compute::{cast, date_part, DatePart};
+use arrow::compute::DatePart;
 use arrow::datatypes::DataType;
 use datafusion::common::Result;
 use datafusion::error::DataFusionError;
@@ -25,18 +24,10 @@ use datafusion::logical_expr::simplify::{ExprSimplifyResult, SimplifyInfo};
 use datafusion::logical_expr::{ColumnarValue, Expr, ScalarUDFImpl, Signature, Volatility};
 use std::any::Any;
 
-use crate::utils::{apply_datepart_kernel, make_scalar_function};
+use crate::utils::apply_datepart_kernel;
 
 fn year_date_invoke(args: &[ColumnarValue]) -> Result<ColumnarValue> {
-    make_scalar_function(year, vec![])(args)
-}
-
-fn year(args: &[ArrayRef]) -> Result<ArrayRef> {
-    let array = &args[0];
-    Ok(cast(
-        date_part(array, DatePart::Year)?.as_ref(),
-        &DataType::Int64,
-    )?)
+    apply_datepart_kernel(&args[0], DatePart::Year)
 }
 
 fn year_date_return_type(_arg_types: &[DataType]) -> Result<DataType> {

--- a/src/trino/year_impl.rs
+++ b/src/trino/year_impl.rs
@@ -25,7 +25,7 @@ use datafusion::logical_expr::simplify::{ExprSimplifyResult, SimplifyInfo};
 use datafusion::logical_expr::{ColumnarValue, Expr, ScalarUDFImpl, Signature, Volatility};
 use std::any::Any;
 
-use crate::utils::make_scalar_function;
+use crate::utils::{apply_datepart_kernel, make_scalar_function};
 
 fn year_date_invoke(args: &[ColumnarValue]) -> Result<ColumnarValue> {
     make_scalar_function(year, vec![])(args)
@@ -62,12 +62,12 @@ fn year_intervalyeartomonth_simplify(
     Ok(ExprSimplifyResult::Original(args))
 }
 
-fn year_timestamp_p_invoke(_args: &[ColumnarValue]) -> Result<ColumnarValue> {
-    Err(DataFusionError::NotImplemented("todo".to_string()))
+fn year_timestamp_p_invoke(args: &[ColumnarValue]) -> Result<ColumnarValue> {
+    apply_datepart_kernel(&args[0], DatePart::Year)
 }
 
 fn year_timestamp_p_return_type(_arg_types: &[DataType]) -> Result<DataType> {
-    Err(DataFusionError::NotImplemented("todo".to_string()))
+    Ok(DataType::Int64)
 }
 
 fn year_timestamp_p_simplify(


### PR DESCRIPTION
That is, these functions can now be called on `timestamp` and `date` or `time` (but not on intervals):
year, month, day, day_of_month, day_of_week / dow, day_of_year / doy, hour, minute, second, millisecond.

The implementation is by calling new convenience methods for applying unary kernels to columnar values.  For uniformity, this also switches a few previously-introduced implementations to these methods (year, month, day).
