### PR TITLE
Switch to a more accurate implementation of from_unixtime

### DIFF
--- a/assets/trino/functions.sdf.yml
+++ b/assets/trino/functions.sdf.yml
@@ -3309,7 +3309,7 @@ function:
   optional-parameters: []
   returns:
     datatype: timestamp
-  implemented-by: !datafusion
+  implemented-by: !rust
   section: datetime
   cross-link: https://trino.io/docs/current/functions/datetime.html#from_unixtime
   description: >


### PR DESCRIPTION
The datafusion implementation that we linked to previously returned second-precision timestamps, while our signature for the Trino function promised millisecond precision.

The implementation is on top of PR #58, since it uses a convenience introduced there. 