### PR TITLE
Re-enable UDFs inadvertently disabled

### DIFF
--- a/assets/trino/functions.sdf.yml
+++ b/assets/trino/functions.sdf.yml
@@ -7156,6 +7156,7 @@ function:
   optional-parameters: []
   returns:
     datatype: decimal(1, 0)
+  implemented-by: !rust
   section: math
   cross-link: https://trino.io/docs/current/functions/math.html#sign
   description: >
@@ -7194,6 +7195,8 @@ function:
   optional-parameters: []
   returns:
     datatype: real
+  implemented-by: !datafusion
+    udf: signum
   section: math
   cross-link: https://trino.io/docs/current/functions/math.html#sign
   description: >
@@ -9110,6 +9113,7 @@ function:
   optional-parameters: []
   returns:
     datatype: decimal(p, s)
+  implemented-by: !rust
   section: math
   cross-link: https://trino.io/docs/current/functions/math.html#truncate
   description: >
@@ -9122,6 +9126,7 @@ function:
   optional-parameters: []
   returns:
     datatype: decimal(rp, 0)
+  implemented-by: !rust
   section: math
   cross-link: https://trino.io/docs/current/functions/math.html#truncate
   description: >


### PR DESCRIPTION

That's sign() and truncate() that got dropped in #56. 

Actually, not re-enabling `sign()` on integer types, since we do not yet have an implementation for those (have floats and decimal). 
