### PR TITLE
modulo of division UDF

### DIFF
--- a/assets/trino/functions.sdf.yml
+++ b/assets/trino/functions.sdf.yml
@@ -5421,6 +5421,7 @@ function:
   optional-parameters: []
   returns:
     datatype: bigint
+  implemented-by: !rust
   section: math
   cross-link: https://trino.io/docs/current/functions/math.html#mod
   description: >
@@ -5447,6 +5448,7 @@ function:
   optional-parameters: []
   returns:
     datatype: double
+  implemented-by: !rust
   section: math
   cross-link: https://trino.io/docs/current/functions/math.html#mod
   description: >


### PR DESCRIPTION
Implemented by connecting to an existing kernel in Arrow. 

Note that only mod(bigint, bigint) and mod(double, double) are currently marked as `implemented-by: !rust`, but all other overloads do execute, by invoking these two. 
This is a general feature/bug that I noticed elsewhere as well and need to investigate separately -- any pointers / explanation are welcome, though. 