### PR TITLE
Regexp UDFs and beginnings of generic vectorization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,6 @@ arrow = { version = "51.0.0", features = ["prettyprint"] }
 tokio = "1.33.0"
 chrono = "0.4"
 chrono-tz = "0.5"
-regex = "1.5"
+regex = "1.10.2"
 log = "0.4.20"
 rust-embed = "6.4.2"

--- a/assets/trino/functions.sdf.yml
+++ b/assets/trino/functions.sdf.yml
@@ -6529,8 +6529,7 @@ function:
   section: regexp
   cross-link: https://trino.io/docs/current/functions/regexp.html#regexp_extract
   description: >
-    Returns the first substring matched by the regular expression pattern
-    in string.
+    Returns the first substring matched in a string by the regular expression pattern.
   examples:
     - input: SELECT REGEXP_EXTRACT('email_address@gmail.com', '@(.*?)\.'
       output: gmail
@@ -6544,11 +6543,11 @@ function:
   optional-parameters: []
   returns:
     datatype: varchar
+  implemented-by: !rust
   section: regexp
   cross-link: https://trino.io/docs/current/functions/regexp.html#regexp_extract
   description: >
-    Returns the first substring matched by the regular expression pattern
-    in string.
+    Returns the first substring matched in a string by the regular expression pattern's capture group.
 ---
 function:
   name: regexp_extract_all

--- a/assets/trino/functions.sdf.yml
+++ b/assets/trino/functions.sdf.yml
@@ -6622,6 +6622,7 @@ function:
   optional-parameters: []
   returns:
     datatype: bigint
+  implemented-by: !rust
   section: regexp
   cross-link: https://trino.io/docs/current/functions/regexp.html#regexp_position
   description: >

--- a/assets/trino/functions.sdf.yml
+++ b/assets/trino/functions.sdf.yml
@@ -6606,6 +6606,7 @@ function:
   optional-parameters: []
   returns:
     datatype: bigint
+  implemented-by: !rust
   section: regexp
   cross-link: https://trino.io/docs/current/functions/regexp.html#regexp_position
   description: >

--- a/assets/trino/functions.sdf.yml
+++ b/assets/trino/functions.sdf.yml
@@ -6639,6 +6639,7 @@ function:
   optional-parameters: []
   returns:
     datatype: bigint
+  implemented-by: !rust
   section: regexp
   cross-link: https://trino.io/docs/current/functions/regexp.html#regexp_position
   description: >

--- a/assets/trino/functions.sdf.yml
+++ b/assets/trino/functions.sdf.yml
@@ -6511,6 +6511,7 @@ function:
   optional-parameters: []
   returns:
     datatype: bigint
+  implemented-by: !rust
   section: regexp
   cross-link: https://trino.io/docs/current/functions/regexp.html#regexp_count
   description: >

--- a/assets/trino/functions.sdf.yml
+++ b/assets/trino/functions.sdf.yml
@@ -6709,6 +6709,7 @@ function:
   optional-parameters: []
   returns:
     datatype: array<varchar>
+  implemented-by: !rust
   section: regexp
   cross-link: https://trino.io/docs/current/functions/regexp.html#regexp_split
   description: >

--- a/assets/trino/functions.sdf.yml
+++ b/assets/trino/functions.sdf.yml
@@ -6558,11 +6558,11 @@ function:
   optional-parameters: []
   returns:
     datatype: array<varchar>
+  implemented-by: !rust
   section: regexp
   cross-link: https://trino.io/docs/current/functions/regexp.html#regexp_extract_all
   description: >
-    Returns the substring(s) matched by the regular expression pattern
-    in string.
+    Returns the substrings of a string matched by the regular expression pattern.
 ---
 function:
   name: regexp_extract_all
@@ -6573,11 +6573,11 @@ function:
   optional-parameters: []
   returns:
     datatype: array<varchar>
+  implemented-by: !rust
   section: regexp
   cross-link: https://trino.io/docs/current/functions/regexp.html#regexp_extract_all
   description: >
-    Returns the substring(s) matched by the regular expression pattern
-    in string.
+    Returns the substrings of a string matched by the regular expression pattern's capturing group.
 ---
 function:
   name: regexp_like

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,3 +24,5 @@ impl Asset {
 }
 
 mod utils;
+
+mod utils_regexp;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,5 +24,5 @@ impl Asset {
 }
 
 mod utils;
-
+mod utils_arrow;
 mod utils_regexp;

--- a/src/trino/regexp_count_impl.rs
+++ b/src/trino/regexp_count_impl.rs
@@ -21,22 +21,31 @@ use datafusion::common::Result;
 use datafusion::error::DataFusionError;
 use datafusion::logical_expr::simplify::{ExprSimplifyResult, SimplifyInfo};
 use datafusion::logical_expr::{ColumnarValue, Expr, ScalarUDFImpl, Signature, Volatility};
+use regex::Regex;
 use std::any::Any;
+use std::sync::Arc;
 
-fn regexp_count_varchar_joniregexp_invoke(_args: &[ColumnarValue]) -> Result<ColumnarValue> {
-    Err(DataFusionError::NotImplemented(format!(
-        "Not implemented {}:{}",
-        file!(),
-        line!()
-    )))
+use crate::utils_regexp::map_rowfun__pat_hay_to_i64;
+
+fn regexp_count_varchar_joniregexp_invoke(args: &[ColumnarValue]) -> Result<ColumnarValue> {
+    map_rowfun__pat_hay_to_i64(&args[1], &args[0], Arc::new(regexp_count__rowfun))
+}
+
+fn regexp_count__rowfun(pat: &str) -> Result<Arc<dyn Fn(/*hay:*/ &str) -> i64>> {
+    let re = Regex::new(pat).map_err(|e| {
+        DataFusionError::Execution(format!(
+            "Regular expression for regexp_count did not compile: {e:?}"
+        ))
+    })?;
+    let rowfun = move |str: &str| {
+        let count = re.find_iter(str).count() as i64;
+        count
+    };
+    Ok(Arc::new(rowfun))
 }
 
 fn regexp_count_varchar_joniregexp_return_type(_arg_types: &[DataType]) -> Result<DataType> {
-    Err(DataFusionError::NotImplemented(format!(
-        "Not implemented {}:{}",
-        file!(),
-        line!()
-    )))
+    Ok(DataType::Int64)
 }
 
 fn regexp_count_varchar_joniregexp_simplify(

--- a/src/trino/regexp_like_impl.rs
+++ b/src/trino/regexp_like_impl.rs
@@ -16,9 +16,7 @@
 // under the License.
 
 #![allow(non_camel_case_types)]
-use arrow::array::{as_fixed_size_list_array, StringArray};
 use arrow::datatypes::DataType;
-use datafusion::common::cast::as_string_array;
 use datafusion::common::Result;
 use datafusion::functions::regex::regexplike::regexp_like;
 use datafusion::logical_expr::simplify::{ExprSimplifyResult, SimplifyInfo};
@@ -26,22 +24,12 @@ use datafusion::logical_expr::{ColumnarValue, Expr, ScalarUDFImpl, Signature, Vo
 use std::any::Any;
 use std::sync::Arc;
 
+use crate::utils::distinct_to_string_array;
+
 fn regexp_like_varchar_joniregexp_invoke(args: &[ColumnarValue]) -> Result<ColumnarValue> {
     let args = ColumnarValue::values_to_arrays(args)?;
     let value = args[0].to_owned();
-    let pattern = args[1].to_owned();
-    // let pattern = cast(&pattern, &DataType::Utf8)?;
-    let pattern = as_fixed_size_list_array(&pattern);
-    let pattern = pattern
-        .iter()
-        .map(|x| {
-            x.map(|x| {
-                let inner = as_string_array(&x)?;
-                Ok(inner.value(0).to_owned())
-            })
-            .transpose()
-        })
-        .collect::<Result<StringArray>>()?;
+    let pattern = distinct_to_string_array(&args[1])?;
 
     let args = vec![value, Arc::new(pattern)];
     let array = regexp_like::<i32>(&args)?;

--- a/src/trino/regexp_position_impl.rs
+++ b/src/trino/regexp_position_impl.rs
@@ -21,22 +21,31 @@ use datafusion::common::Result;
 use datafusion::error::DataFusionError;
 use datafusion::logical_expr::simplify::{ExprSimplifyResult, SimplifyInfo};
 use datafusion::logical_expr::{ColumnarValue, Expr, ScalarUDFImpl, Signature, Volatility};
+use regex::Regex;
 use std::any::Any;
+use std::sync::Arc;
 
-fn regexp_position_varchar_joniregexp_invoke(_args: &[ColumnarValue]) -> Result<ColumnarValue> {
-    Err(DataFusionError::NotImplemented(format!(
-        "Not implemented {}:{}",
-        file!(),
-        line!()
-    )))
+use crate::utils_regexp::map_rowfun__pat_hay_to_i64;
+
+fn regexp_position_varchar_joniregexp_invoke(args: &[ColumnarValue]) -> Result<ColumnarValue> {
+    map_rowfun__pat_hay_to_i64(&args[1], &args[0], Arc::new(regexp_position__rowfun))
+}
+
+fn regexp_position__rowfun(pat: &str) -> Result<Arc<dyn Fn(/*hay:*/ &str) -> i64>> {
+    let re = Regex::new(pat).map_err(|e| {
+        DataFusionError::Execution(format!(
+            "Regular expression for regexp_position did not compile: {e:?}"
+        ))
+    })?;
+    let rowfun = move |str: &str| match re.find(str) {
+        None => -1,
+        Some(m) => m.start() as i64 + 1,
+    };
+    Ok(Arc::new(rowfun))
 }
 
 fn regexp_position_varchar_joniregexp_return_type(_arg_types: &[DataType]) -> Result<DataType> {
-    Err(DataFusionError::NotImplemented(format!(
-        "Not implemented {}:{}",
-        file!(),
-        line!()
-    )))
+    Ok(DataType::Int64)
 }
 
 fn regexp_position_varchar_joniregexp_simplify(

--- a/src/trino/regexp_split_impl.rs
+++ b/src/trino/regexp_split_impl.rs
@@ -21,22 +21,31 @@ use datafusion::common::Result;
 use datafusion::error::DataFusionError;
 use datafusion::logical_expr::simplify::{ExprSimplifyResult, SimplifyInfo};
 use datafusion::logical_expr::{ColumnarValue, Expr, ScalarUDFImpl, Signature, Volatility};
+use regex::Regex;
 use std::any::Any;
+use std::sync::Arc;
 
-fn regexp_split_varchar_joniregexp_invoke(_args: &[ColumnarValue]) -> Result<ColumnarValue> {
-    Err(DataFusionError::NotImplemented(format!(
-        "Not implemented {}:{}",
-        file!(),
-        line!()
-    )))
+use crate::utils_regexp::map_rowfun__pat_hay_to_strlst;
+
+fn regexp_split_varchar_joniregexp_invoke(args: &[ColumnarValue]) -> Result<ColumnarValue> {
+    map_rowfun__pat_hay_to_strlst(&args[1], &args[0], Arc::new(regexp_split__rowfun))
+}
+
+fn regexp_split__rowfun(
+    pat: &str,
+) -> Result<Arc<dyn for<'a> Fn(/*hay:*/ &'a str) -> Vec<&'a str>>> {
+    let re = Regex::new(pat).map_err(|e| {
+        DataFusionError::Execution(format!(
+            "Regular expression for regexp_count did not compile: {e:?}"
+        ))
+    })?;
+    let rowfun: Arc<dyn for<'a> Fn(/*hay:*/ &'a str) -> Vec<&'a str>> =
+        Arc::new(move |hay: &str| re.split(hay).collect());
+    Ok(rowfun)
 }
 
 fn regexp_split_varchar_joniregexp_return_type(_arg_types: &[DataType]) -> Result<DataType> {
-    Err(DataFusionError::NotImplemented(format!(
-        "Not implemented {}:{}",
-        file!(),
-        line!()
-    )))
+    Ok(DataType::new_list(DataType::Utf8, false))
 }
 
 fn regexp_split_varchar_joniregexp_simplify(

--- a/src/utils_arrow.rs
+++ b/src/utils_arrow.rs
@@ -1,0 +1,92 @@
+use arrow::array::ListArray;
+use arrow::array::ListBuilder;
+use arrow::array::StringArray;
+use arrow::array::StringBuilder;
+
+pub(crate) struct StringArrayExt(StringArray);
+
+impl StringArrayExt {
+    pub fn into_string_array(self) -> StringArray {
+        self.0
+    }
+}
+
+/// Enables collect::<ListArrayExt> from an Iterator of Option<Vec<&'a str>>,
+/// where None represents a null list.
+impl<'a> FromIterator<Option<&'a str>> for StringArrayExt {
+    fn from_iter<I>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = Option<&'a str>>,
+    {
+        let mut builder = StringBuilder::new();
+        for item in iter {
+            match item {
+                Some(s) => {
+                    builder.append_value(s);
+                }
+                None => {
+                    builder.append_null();
+                }
+            }
+        }
+        StringArrayExt(builder.finish())
+    }
+}
+
+pub(crate) struct ListArrayExt(ListArray);
+
+impl ListArrayExt {
+    pub fn into_list_array(self) -> ListArray {
+        self.0
+    }
+}
+
+/// Enables collect::<ListArrayExt> from an Iterator of Option<Vec<&'a str>>,
+/// where None represents a null list.
+impl<'a> FromIterator<Option<Vec<&'a str>>> for ListArrayExt {
+    fn from_iter<I>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = Option<Vec<&'a str>>>,
+    {
+        let mut builder = ListBuilder::new(StringBuilder::new());
+        for item in iter {
+            match item {
+                Some(vec) => {
+                    for s in vec {
+                        builder.values().append_value(s);
+                    }
+                    builder.append(true);
+                }
+                None => {
+                    builder.append(false);
+                }
+            }
+        }
+        ListArrayExt(builder.finish())
+    }
+}
+
+/// Enables collect::<ListArrayExt> from an Iterator of Option<Vec<Option<&'a str>>>,
+/// where None represents a null list and a null string in a list.
+impl<'a> FromIterator<Option<Vec<Option<&'a str>>>> for ListArrayExt {
+    fn from_iter<I>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = Option<Vec<Option<&'a str>>>>,
+    {
+        let mut builder = ListBuilder::new(StringBuilder::new());
+        for item in iter {
+            match item {
+                Some(vec) => {
+                    for s in vec {
+                        builder.values().append_option(s);
+                    }
+                    builder.append(true);
+                }
+                None => {
+                    builder.append(false);
+                }
+            }
+        }
+        ListArrayExt(builder.finish())
+    }
+}

--- a/src/utils_regexp.rs
+++ b/src/utils_regexp.rs
@@ -1,0 +1,95 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Helper functors for creating Regexp-based UDFs.
+//! As with UDF functors in general, the idea is to have a generic implementation of
+//! vectorization machinery that can accept a simple function defined over fields of a row
+//! and map it over `ColumnarValue` inputs.
+//! The functors here address Regexp specifics as follows:
+//! - The case of the pattern column being a scalar is recognized and optimized for by compiling the
+//!   pattern only once. (This case corresponds to a literal-string pattern in an SQL query.)
+//! - Row functions are curried, with the first argument being a string for the regexp pattern.
+//!   (This is different from the argument order in UDFs, but is better suited the regexp pre-compiling.)
+//! - The pattern column (the first column) is assumed to be an SDF "distinct" type `joniregexp`
+//!   and is handled suitably to extract the underlying string array.
+//! Functor names are of the form map_rowfun__aaa_bbb_ccc_to_zzz,
+//! where aaa, bbb, ccc, ... (up to `to`) indicate the types of the columns and of the row function's arguments,
+//! while zzz indicates the output type.
+
+#![allow(non_snake_case)]
+use arrow::array::{Array, ArrayRef, Int64Array};
+use datafusion::common::cast::as_string_array;
+use datafusion::common::Result;
+use datafusion::logical_expr::ColumnarValue;
+use std::sync::Arc;
+
+use crate::utils::{array_to_columnar, distinct_to_string_array};
+
+/// Map a curried row function that accepts a pattern and a string and returns an i64
+/// over two columns, of jonigexp and haystack/string.  
+pub(super) fn map_rowfun__pat_hay_to_i64<F>(
+    joni_col: &ColumnarValue,
+    hay_col: &ColumnarValue,
+    rowfun: Arc<F>,
+) -> Result<ColumnarValue>
+where
+    F: (Fn(/*pat:*/ &str) -> Result<Arc<dyn Fn(/*hay:*/ &str) -> i64>>) + Sync + Send + 'static,
+{
+    let res_arr = match joni_col {
+        ColumnarValue::Array(joni_arr) => {
+            let hay_arr = hay_col.to_owned().into_array(joni_arr.len())?;
+            let pattern = distinct_to_string_array(joni_arr)?;
+            let haystack = as_string_array(&hay_arr)?;
+            let res = pattern
+                .iter()
+                .zip(haystack.iter())
+                .map(|(pat_opt, hay_opt)| match (pat_opt, hay_opt) {
+                    (Some(pat), Some(hay)) => {
+                        let regfun = rowfun(pat)?;
+                        Ok(Some(regfun(hay)))
+                    }
+                    _ => Ok(None),
+                })
+                .collect::<Result<Int64Array>>()?;
+            Arc::new(res) as ArrayRef
+        }
+        ColumnarValue::Scalar(joni_scalar) => {
+            let hay_arr = hay_col.to_owned().into_array(1)?; // NB: 1 only triggers when hay_col is Scalar
+            let joni_arr = joni_scalar.to_array()?;
+            let pat_arr = distinct_to_string_array(&joni_arr)?;
+            if pat_arr.is_null(0) {
+                arrow::array::new_null_array(hay_arr.data_type(), hay_arr.len())
+            } else {
+                let pat = pat_arr.value(0);
+                let regfun = rowfun(pat)?;
+                let haystack = as_string_array(&hay_arr)?;
+                let res = haystack
+                    .iter()
+                    .map(|hay_opt| match hay_opt {
+                        Some(hay) => {
+                            // core action
+                            Some(regfun(hay))
+                        }
+                        _ => None,
+                    })
+                    .collect::<Int64Array>();
+                Arc::new(res) as ArrayRef
+            }
+        }
+    };
+    Ok(array_to_columnar(res_arr))
+}

--- a/src/utils_regexp.rs
+++ b/src/utils_regexp.rs
@@ -38,6 +38,7 @@ use datafusion::logical_expr::ColumnarValue;
 use std::sync::Arc;
 
 use crate::utils::{array_to_columnar, distinct_to_string_array};
+use crate::utils_arrow::ListArrayExt;
 
 /// Map a curried row function that accepts a pattern and a string and returns an i64
 /// over two columns, of jonigexp and haystack/string.  
@@ -116,15 +117,13 @@ where
                 .iter()
                 .zip(haystack.iter())
                 .zip(int1.iter())
-                .map(
-                    |((pat_opt, hay_opt), int1_opt)| match ((pat_opt, hay_opt), int1_opt) {
-                        ((Some(pat), Some(hay)), Some(int1)) => {
-                            let regfun = rowfun(pat)?;
-                            Ok(Some(regfun(hay, int1)))
-                        }
-                        _ => Ok(None),
-                    },
-                )
+                .map(|tuple| match tuple {
+                    ((Some(pat), Some(hay)), Some(int1)) => {
+                        let regfun = rowfun(pat)?;
+                        Ok(Some(regfun(hay, int1)))
+                    }
+                    _ => Ok(None),
+                })
                 .collect::<Result<Int64Array>>()?;
             Arc::new(res) as ArrayRef
         }
@@ -143,7 +142,7 @@ where
                 let res = haystack
                     .iter()
                     .zip(int1.iter())
-                    .map(|(hay_opt, int1_opt)| match (hay_opt, int1_opt) {
+                    .map(|tuple| match tuple {
                         (Some(hay), Some(int1)) => Some(regfun(hay, int1)),
                         _ => None,
                     })
@@ -218,6 +217,126 @@ where
                     })
                     .collect::<Int64Array>();
                 Arc::new(res) as ArrayRef
+            }
+        }
+    };
+    Ok(array_to_columnar(res_arr))
+}
+
+/// Given a pattern-curried row function that returns a Vec of non-nullable strings,
+/// map it over columns, returning a column of string lists.  
+pub(super) fn map_rowfun__pat_hay_to_strlst<F>(
+    joni_col: &ColumnarValue,
+    hay_col: &ColumnarValue,
+    rowfun: Arc<F>,
+) -> Result<ColumnarValue>
+where
+    F: (Fn(/*pat:*/ &str) -> Result<Arc<dyn for<'a> Fn(/*hay:*/ &'a str) -> Vec<&'a str>>>)
+        + Sync
+        + Send
+        + 'static,
+{
+    let res_arr = match joni_col {
+        ColumnarValue::Array(joni_arr) => {
+            let hay_arr = hay_col.to_owned().into_array(joni_arr.len())?;
+            let pattern = distinct_to_string_array(joni_arr)?;
+            let haystack = as_string_array(&hay_arr)?;
+            let res = pattern
+                .iter()
+                .zip(haystack.iter())
+                .map(|(pat_opt, hay_opt)| match (pat_opt, hay_opt) {
+                    (Some(pat), Some(hay)) => {
+                        let regfun = rowfun(pat)?;
+                        Ok(Some(regfun(hay)))
+                    }
+                    _ => Ok(None),
+                })
+                .collect::<Result<ListArrayExt>>()?;
+            Arc::new(res.into_list_array()) as ArrayRef
+        }
+        ColumnarValue::Scalar(joni_scalar) => {
+            let hay_arr = hay_col.to_owned().into_array(1)?; // NB: 1 only triggers when hay_col is Scalar
+            let joni_arr = joni_scalar.to_array()?;
+            let pat_arr = distinct_to_string_array(&joni_arr)?;
+            if pat_arr.is_null(0) {
+                arrow::array::new_null_array(hay_arr.data_type(), hay_arr.len())
+            } else {
+                let pat = pat_arr.value(0);
+                let regfun = rowfun(pat)?;
+                let haystack = as_string_array(&hay_arr)?;
+                let res = haystack
+                    .iter()
+                    .map(|hay_opt| match hay_opt {
+                        Some(hay) => Some(regfun(hay)),
+                        _ => None,
+                    })
+                    .collect::<ListArrayExt>();
+                Arc::new(res.into_list_array()) as ArrayRef
+            }
+        }
+    };
+    Ok(array_to_columnar(res_arr))
+}
+
+/// Given a pattern-curried row function that returns a Vec of nullable strings,
+/// map it over columns, returning a column of string lists.  
+pub(super) fn map_rowfun__pat_hay_int_to_nstrlst<F>(
+    joni_col: &ColumnarValue,
+    hay_col: &ColumnarValue,
+    int1_col: &ColumnarValue,
+    rowfun: Arc<F>,
+) -> Result<ColumnarValue>
+where
+    F: (Fn(
+            /*pat:*/ &str,
+        )
+            -> Result<Arc<dyn for<'a> Fn(/*hay:*/ &'a str, /*int1:*/ i64) -> Vec<Option<&'a str>>>>)
+        + Sync
+        + Send
+        + 'static,
+{
+    let res_arr = match joni_col {
+        ColumnarValue::Array(joni_arr) => {
+            let hay_arr = hay_col.to_owned().into_array(joni_arr.len())?;
+            let int1_arr = int1_col.to_owned().into_array(joni_arr.len())?;
+            let pattern = distinct_to_string_array(joni_arr)?;
+            let haystack = as_string_array(&hay_arr)?;
+            let int1 = as_int64_array(&int1_arr)?;
+            let res = pattern
+                .iter()
+                .zip(haystack.iter())
+                .zip(int1.iter())
+                .map(|tuple| match tuple {
+                    ((Some(pat), Some(hay)), Some(int1)) => {
+                        let regfun = rowfun(pat)?;
+                        Ok(Some(regfun(hay, int1)))
+                    }
+                    _ => Ok(None),
+                })
+                .collect::<Result<ListArrayExt>>()?;
+            Arc::new(res.into_list_array()) as ArrayRef
+        }
+        ColumnarValue::Scalar(joni_scalar) => {
+            let hay_arr = hay_col.to_owned().into_array(1)?; // NB: 1 only triggers when hay_col is Scalar
+            let int1_arr = int1_col.to_owned().into_array(1)?;
+            let joni_arr = joni_scalar.to_array()?;
+            let pat_arr = distinct_to_string_array(&joni_arr)?;
+            if pat_arr.is_null(0) {
+                arrow::array::new_null_array(hay_arr.data_type(), hay_arr.len())
+            } else {
+                let pat = pat_arr.value(0);
+                let regfun = rowfun(pat)?;
+                let haystack = as_string_array(&hay_arr)?;
+                let int1 = as_int64_array(&int1_arr)?;
+                let res = haystack
+                    .iter()
+                    .zip(int1.iter())
+                    .map(|tuple| match tuple {
+                        (Some(hay), Some(int1)) => Some(regfun(hay, int1)),
+                        _ => None,
+                    })
+                    .collect::<ListArrayExt>();
+                Arc::new(res.into_list_array()) as ArrayRef
             }
         }
     };

--- a/src/utils_regexp.rs
+++ b/src/utils_regexp.rs
@@ -38,7 +38,7 @@ use datafusion::logical_expr::ColumnarValue;
 use std::sync::Arc;
 
 use crate::utils::{array_to_columnar, distinct_to_string_array};
-use crate::utils_arrow::ListArrayExt;
+use crate::utils_arrow::{ListArrayExt, StringArrayExt};
 
 /// Map a curried row function that accepts a pattern and a string and returns an i64
 /// over two columns, of jonigexp and haystack/string.  
@@ -217,6 +217,72 @@ where
                     })
                     .collect::<Int64Array>();
                 Arc::new(res) as ArrayRef
+            }
+        }
+    };
+    Ok(array_to_columnar(res_arr))
+}
+
+// map_rowfun__pat_hay_int_to_nstr
+/// Given a pattern-curried row function that returns a nullable string,
+/// map it over columns, returning a column of strings.  
+pub(super) fn map_rowfun__pat_hay_int_to_nstr<F>(
+    joni_col: &ColumnarValue,
+    hay_col: &ColumnarValue,
+    int1_col: &ColumnarValue,
+    rowfun: Arc<F>,
+) -> Result<ColumnarValue>
+where
+    F: (Fn(
+            /*pat:*/ &str,
+        )
+            -> Result<Arc<dyn for<'a> Fn(/*hay:*/ &'a str, /*int1:*/ i64) -> Option<&'a str>>>)
+        + Sync
+        + Send
+        + 'static,
+{
+    let res_arr = match joni_col {
+        ColumnarValue::Array(joni_arr) => {
+            let hay_arr = hay_col.to_owned().into_array(joni_arr.len())?;
+            let int1_arr = int1_col.to_owned().into_array(joni_arr.len())?;
+            let pattern = distinct_to_string_array(joni_arr)?;
+            let haystack = as_string_array(&hay_arr)?;
+            let int1 = as_int64_array(&int1_arr)?;
+            let res = pattern
+                .iter()
+                .zip(haystack.iter())
+                .zip(int1.iter())
+                .map(|tuple| match tuple {
+                    ((Some(pat), Some(hay)), Some(int1)) => {
+                        let regfun = rowfun(pat)?;
+                        Ok(regfun(hay, int1))
+                    }
+                    _ => Ok(None),
+                })
+                .collect::<Result<StringArrayExt>>()?;
+            Arc::new(res.into_string_array()) as ArrayRef
+        }
+        ColumnarValue::Scalar(joni_scalar) => {
+            let hay_arr = hay_col.to_owned().into_array(1)?; // NB: 1 only triggers when hay_col is Scalar
+            let int1_arr = int1_col.to_owned().into_array(1)?;
+            let joni_arr = joni_scalar.to_array()?;
+            let pat_arr = distinct_to_string_array(&joni_arr)?;
+            if pat_arr.is_null(0) {
+                arrow::array::new_null_array(hay_arr.data_type(), hay_arr.len())
+            } else {
+                let pat = pat_arr.value(0);
+                let regfun = rowfun(pat)?;
+                let haystack = as_string_array(&hay_arr)?;
+                let int1 = as_int64_array(&int1_arr)?;
+                let res = haystack
+                    .iter()
+                    .zip(int1.iter())
+                    .map(|tuple| match tuple {
+                        (Some(hay), Some(int1)) => regfun(hay, int1),
+                        _ => None,
+                    })
+                    .collect::<StringArrayExt>();
+                Arc::new(res.into_string_array()) as ArrayRef
             }
         }
     };

--- a/src/utils_regexp.rs
+++ b/src/utils_regexp.rs
@@ -32,7 +32,7 @@
 
 #![allow(non_snake_case)]
 use arrow::array::{Array, ArrayRef, Int64Array};
-use datafusion::common::cast::as_string_array;
+use datafusion::common::cast::{as_int64_array, as_string_array};
 use datafusion::common::Result;
 use datafusion::logical_expr::ColumnarValue;
 use std::sync::Arc;
@@ -80,10 +80,71 @@ where
                 let res = haystack
                     .iter()
                     .map(|hay_opt| match hay_opt {
-                        Some(hay) => {
-                            // core action
-                            Some(regfun(hay))
+                        Some(hay) => Some(regfun(hay)),
+                        _ => None,
+                    })
+                    .collect::<Int64Array>();
+                Arc::new(res) as ArrayRef
+            }
+        }
+    };
+    Ok(array_to_columnar(res_arr))
+}
+
+/// Map a curried row function that accepts a pattern, a string, and an integer and returns an i64
+/// over three columns, of jonigexp, haystack/string, and integers.  
+pub(super) fn map_rowfun__pat_hay_int_to_i64<F>(
+    joni_col: &ColumnarValue,
+    hay_col: &ColumnarValue,
+    int1_col: &ColumnarValue,
+    rowfun: Arc<F>,
+) -> Result<ColumnarValue>
+where
+    F: (Fn(/*pat:*/ &str) -> Result<Arc<dyn Fn(/*hay:*/ &str, /*int1:*/ i64) -> i64>>)
+        + Sync
+        + Send
+        + 'static,
+{
+    let res_arr = match joni_col {
+        ColumnarValue::Array(joni_arr) => {
+            let hay_arr = hay_col.to_owned().into_array(joni_arr.len())?;
+            let int1_arr = int1_col.to_owned().into_array(joni_arr.len())?;
+            let pattern = distinct_to_string_array(joni_arr)?;
+            let haystack = as_string_array(&hay_arr)?;
+            let int1 = as_int64_array(&int1_arr)?;
+            let res = pattern
+                .iter()
+                .zip(haystack.iter())
+                .zip(int1.iter())
+                .map(
+                    |((pat_opt, hay_opt), int1_opt)| match ((pat_opt, hay_opt), int1_opt) {
+                        ((Some(pat), Some(hay)), Some(int1)) => {
+                            let regfun = rowfun(pat)?;
+                            Ok(Some(regfun(hay, int1)))
                         }
+                        _ => Ok(None),
+                    },
+                )
+                .collect::<Result<Int64Array>>()?;
+            Arc::new(res) as ArrayRef
+        }
+        ColumnarValue::Scalar(joni_scalar) => {
+            let hay_arr = hay_col.to_owned().into_array(1)?; // NB: 1 only triggers when hay_col is Scalar
+            let int1_arr = int1_col.to_owned().into_array(1)?;
+            let joni_arr = joni_scalar.to_array()?;
+            let pat_arr = distinct_to_string_array(&joni_arr)?;
+            if pat_arr.is_null(0) {
+                arrow::array::new_null_array(hay_arr.data_type(), hay_arr.len())
+            } else {
+                let pat = pat_arr.value(0);
+                let regfun = rowfun(pat)?;
+                let haystack = as_string_array(&hay_arr)?;
+                let int1 = as_int64_array(&int1_arr)?;
+                let res = haystack
+                    .iter()
+                    .zip(int1.iter())
+                    .map(|(hay_opt, int1_opt)| match (hay_opt, int1_opt) {
+                        (Some(hay), Some(int1)) => Some(regfun(hay, int1)),
                         _ => None,
                     })
                     .collect::<Int64Array>();


### PR DESCRIPTION
This brings in all the remaining regexp-involving Trino UDFs (except the overload of regexp_replace that has a lambda argument).

They are implemented with the help of a nascent framework for implementing UDFs by lifting / mapping relatively simple row functions to vectorized operations on columns. 
The framework is in its very beginning and still relies on excessive cut-paste-modify activity, but already provides some effort savings. 
Improvement advice or discussions from those more experienced with Rust and Arrow will be gladly appreciated and incorporated!


