### PR TITLE
Re-implement regexp_replace via the vectorization helpers.

### DIFF
--- a/src/trino/regexp_count_impl.rs
+++ b/src/trino/regexp_count_impl.rs
@@ -37,10 +37,7 @@ fn regexp_count__rowfun(pat: &str) -> Result<Arc<dyn Fn(/*hay:*/ &str) -> i64>> 
             "Regular expression for regexp_count did not compile: {e:?}"
         ))
     })?;
-    let rowfun = move |str: &str| {
-        let count = re.find_iter(str).count() as i64;
-        count
-    };
+    let rowfun = move |str: &str| re.find_iter(str).count() as i64;
     Ok(Arc::new(rowfun))
 }
 

--- a/src/utils_arrow.rs
+++ b/src/utils_arrow.rs
@@ -11,12 +11,34 @@ impl StringArrayExt {
     }
 }
 
-/// Enables collect::<ListArrayExt> from an Iterator of Option<Vec<&'a str>>,
+/// Enables collect::<ListArrayExt> from an Iterator of Option<&'a str>,
 /// where None represents a null list.
 impl<'a> FromIterator<Option<&'a str>> for StringArrayExt {
     fn from_iter<I>(iter: I) -> Self
     where
         I: IntoIterator<Item = Option<&'a str>>,
+    {
+        let mut builder = StringBuilder::new();
+        for item in iter {
+            match item {
+                Some(s) => {
+                    builder.append_value(s);
+                }
+                None => {
+                    builder.append_null();
+                }
+            }
+        }
+        StringArrayExt(builder.finish())
+    }
+}
+
+/// Enables collect::<ListArrayExt> from an Iterator of Option<String>,
+/// where None represents a null list.
+impl<'a> FromIterator<Option<String>> for StringArrayExt {
+    fn from_iter<I>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = Option<String>>,
     {
         let mut builder = StringBuilder::new();
         for item in iter {


### PR DESCRIPTION
Fixes #50.

Our previous implementation was adapting the implementation from DataFusion, which in turn uses the same regexp crate. 
The fact that it now behaves correctly indicates that something goes wrong in the DataFusion's implementation.  That's a 3rd-party example that vectorization is easy to get wrong. 