### PR TITLE
An sdf make-functions refresher run

### DIFF
--- a/src/trino/abs_impl.rs
+++ b/src/trino/abs_impl.rs
@@ -150,13 +150,14 @@ fn abs_real_simplify(args: Vec<Expr>, _info: &dyn SimplifyInfo) -> Result<ExprSi
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct abs_tinyintFunc {
     signature: Signature,
 }
 
 impl abs_tinyintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -175,6 +176,7 @@ impl ScalarUDFImpl for abs_tinyintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         abs_tinyint_return_type(arg_types)
     }
@@ -183,9 +185,14 @@ impl ScalarUDFImpl for abs_tinyintFunc {
         abs_tinyint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         abs_tinyint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -194,7 +201,7 @@ pub(super) struct abs_smallintFunc {
 }
 
 impl abs_smallintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -213,6 +220,7 @@ impl ScalarUDFImpl for abs_smallintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         abs_smallint_return_type(arg_types)
     }
@@ -221,9 +229,14 @@ impl ScalarUDFImpl for abs_smallintFunc {
         abs_smallint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         abs_smallint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -232,7 +245,7 @@ pub(super) struct abs_bigintFunc {
 }
 
 impl abs_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -251,6 +264,7 @@ impl ScalarUDFImpl for abs_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         abs_bigint_return_type(arg_types)
     }
@@ -259,9 +273,14 @@ impl ScalarUDFImpl for abs_bigintFunc {
         abs_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         abs_bigint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -270,7 +289,7 @@ pub(super) struct abs_doubleFunc {
 }
 
 impl abs_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -289,6 +308,7 @@ impl ScalarUDFImpl for abs_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         abs_double_return_type(arg_types)
     }
@@ -297,9 +317,14 @@ impl ScalarUDFImpl for abs_doubleFunc {
         abs_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         abs_double_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -308,7 +333,7 @@ pub(super) struct abs_decimal_p_sFunc {
 }
 
 impl abs_decimal_p_sFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -327,6 +352,7 @@ impl ScalarUDFImpl for abs_decimal_p_sFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         abs_decimal_p_s_return_type(arg_types)
     }
@@ -335,9 +361,14 @@ impl ScalarUDFImpl for abs_decimal_p_sFunc {
         abs_decimal_p_s_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         abs_decimal_p_s_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -346,7 +377,7 @@ pub(super) struct abs_realFunc {
 }
 
 impl abs_realFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -365,6 +396,7 @@ impl ScalarUDFImpl for abs_realFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         abs_real_return_type(arg_types)
     }
@@ -373,7 +405,12 @@ impl ScalarUDFImpl for abs_realFunc {
         abs_real_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         abs_real_simplify(args, info)
     }
+
 }

--- a/src/trino/acos_impl.rs
+++ b/src/trino/acos_impl.rs
@@ -47,13 +47,14 @@ fn acos_double_simplify(args: Vec<Expr>, _info: &dyn SimplifyInfo) -> Result<Exp
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct acos_doubleFunc {
     signature: Signature,
 }
 
 impl acos_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -72,6 +73,7 @@ impl ScalarUDFImpl for acos_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         acos_double_return_type(arg_types)
     }
@@ -80,7 +82,12 @@ impl ScalarUDFImpl for acos_doubleFunc {
         acos_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         acos_double_simplify(args, info)
     }
+
 }

--- a/src/trino/all_match_impl.rs
+++ b/src/trino/all_match_impl.rs
@@ -50,13 +50,14 @@ fn all_match_array_1_function_1_boolean_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct all_match_array_1_function_1_booleanFunc {
     signature: Signature,
 }
 
 impl all_match_array_1_function_1_booleanFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for all_match_array_1_function_1_booleanFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         all_match_array_1_function_1_boolean_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for all_match_array_1_function_1_booleanFunc {
         all_match_array_1_function_1_boolean_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         all_match_array_1_function_1_boolean_simplify(args, info)
     }
+
 }

--- a/src/trino/any_match_impl.rs
+++ b/src/trino/any_match_impl.rs
@@ -50,13 +50,14 @@ fn any_match_array_1_function_1_boolean_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct any_match_array_1_function_1_booleanFunc {
     signature: Signature,
 }
 
 impl any_match_array_1_function_1_booleanFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for any_match_array_1_function_1_booleanFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         any_match_array_1_function_1_boolean_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for any_match_array_1_function_1_booleanFunc {
         any_match_array_1_function_1_boolean_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         any_match_array_1_function_1_boolean_simplify(args, info)
     }
+
 }

--- a/src/trino/array_distinct_impl.rs
+++ b/src/trino/array_distinct_impl.rs
@@ -50,13 +50,14 @@ fn array_distinct_array_3_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct array_distinct_array_3Func {
     signature: Signature,
 }
 
 impl array_distinct_array_3Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for array_distinct_array_3Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         array_distinct_array_3_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for array_distinct_array_3Func {
         array_distinct_array_3_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         array_distinct_array_3_simplify(args, info)
     }
+
 }

--- a/src/trino/array_except_impl.rs
+++ b/src/trino/array_except_impl.rs
@@ -50,13 +50,14 @@ fn array_except_array_3_array_3_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct array_except_array_3_array_3Func {
     signature: Signature,
 }
 
 impl array_except_array_3_array_3Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for array_except_array_3_array_3Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         array_except_array_3_array_3_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for array_except_array_3_array_3Func {
         array_except_array_3_array_3_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         array_except_array_3_array_3_simplify(args, info)
     }
+
 }

--- a/src/trino/array_intersect_impl.rs
+++ b/src/trino/array_intersect_impl.rs
@@ -50,13 +50,14 @@ fn array_intersect_array_3_array_3_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct array_intersect_array_3_array_3Func {
     signature: Signature,
 }
 
 impl array_intersect_array_3_array_3Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for array_intersect_array_3_array_3Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         array_intersect_array_3_array_3_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for array_intersect_array_3_array_3Func {
         array_intersect_array_3_array_3_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         array_intersect_array_3_array_3_simplify(args, info)
     }
+
 }

--- a/src/trino/array_join_impl.rs
+++ b/src/trino/array_join_impl.rs
@@ -73,13 +73,14 @@ fn array_join_array_1_varchar_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct array_join_array_1_varcharFunc {
     signature: Signature,
 }
 
 impl array_join_array_1_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -98,6 +99,7 @@ impl ScalarUDFImpl for array_join_array_1_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         array_join_array_1_varchar_return_type(arg_types)
     }
@@ -106,9 +108,14 @@ impl ScalarUDFImpl for array_join_array_1_varcharFunc {
         array_join_array_1_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         array_join_array_1_varchar_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -117,7 +124,7 @@ pub(super) struct array_join_array_1_varchar_varcharFunc {
 }
 
 impl array_join_array_1_varchar_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(3, Volatility::Immutable),
         }
@@ -136,6 +143,7 @@ impl ScalarUDFImpl for array_join_array_1_varchar_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         array_join_array_1_varchar_varchar_return_type(arg_types)
     }
@@ -144,7 +152,12 @@ impl ScalarUDFImpl for array_join_array_1_varchar_varcharFunc {
         array_join_array_1_varchar_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         array_join_array_1_varchar_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/array_max_impl.rs
+++ b/src/trino/array_max_impl.rs
@@ -77,13 +77,14 @@ fn array_max_array_1_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct array_max_array_1Func {
     signature: Signature,
 }
 
 impl array_max_array_1Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -102,6 +103,7 @@ impl ScalarUDFImpl for array_max_array_1Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         array_max_array_1_return_type(arg_types)
     }
@@ -110,7 +112,12 @@ impl ScalarUDFImpl for array_max_array_1Func {
         array_max_array_1_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         array_max_array_1_simplify(args, info)
     }
+
 }

--- a/src/trino/array_min_impl.rs
+++ b/src/trino/array_min_impl.rs
@@ -77,13 +77,14 @@ fn array_min_array_1_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct array_min_array_1Func {
     signature: Signature,
 }
 
 impl array_min_array_1Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -102,6 +103,7 @@ impl ScalarUDFImpl for array_min_array_1Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         array_min_array_1_return_type(arg_types)
     }
@@ -110,7 +112,12 @@ impl ScalarUDFImpl for array_min_array_1Func {
         array_min_array_1_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         array_min_array_1_simplify(args, info)
     }
+
 }

--- a/src/trino/array_position_impl.rs
+++ b/src/trino/array_position_impl.rs
@@ -50,13 +50,14 @@ fn array_position_array_1_1_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct array_position_array_1_1Func {
     signature: Signature,
 }
 
 impl array_position_array_1_1Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for array_position_array_1_1Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         array_position_array_1_1_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for array_position_array_1_1Func {
         array_position_array_1_1_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         array_position_array_1_1_simplify(args, info)
     }
+
 }

--- a/src/trino/array_remove_impl.rs
+++ b/src/trino/array_remove_impl.rs
@@ -50,13 +50,14 @@ fn array_remove_array_3_3_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct array_remove_array_3_3Func {
     signature: Signature,
 }
 
 impl array_remove_array_3_3Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for array_remove_array_3_3Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         array_remove_array_3_3_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for array_remove_array_3_3Func {
         array_remove_array_3_3_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         array_remove_array_3_3_simplify(args, info)
     }
+
 }

--- a/src/trino/array_sort_impl.rs
+++ b/src/trino/array_sort_impl.rs
@@ -73,13 +73,14 @@ fn array_sort_array_1_function_1_1_bigint_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct array_sort_array_3Func {
     signature: Signature,
 }
 
 impl array_sort_array_3Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -98,6 +99,7 @@ impl ScalarUDFImpl for array_sort_array_3Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         array_sort_array_3_return_type(arg_types)
     }
@@ -106,9 +108,14 @@ impl ScalarUDFImpl for array_sort_array_3Func {
         array_sort_array_3_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         array_sort_array_3_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -117,7 +124,7 @@ pub(super) struct array_sort_array_1_function_1_1_bigintFunc {
 }
 
 impl array_sort_array_1_function_1_1_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -136,6 +143,7 @@ impl ScalarUDFImpl for array_sort_array_1_function_1_1_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         array_sort_array_1_function_1_1_bigint_return_type(arg_types)
     }
@@ -144,7 +152,12 @@ impl ScalarUDFImpl for array_sort_array_1_function_1_1_bigintFunc {
         array_sort_array_1_function_1_1_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         array_sort_array_1_function_1_1_bigint_simplify(args, info)
     }
+
 }

--- a/src/trino/array_union_impl.rs
+++ b/src/trino/array_union_impl.rs
@@ -50,13 +50,14 @@ fn array_union_array_3_array_3_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct array_union_array_3_array_3Func {
     signature: Signature,
 }
 
 impl array_union_array_3_array_3Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for array_union_array_3_array_3Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         array_union_array_3_array_3_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for array_union_array_3_array_3Func {
         array_union_array_3_array_3_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         array_union_array_3_array_3_simplify(args, info)
     }
+
 }

--- a/src/trino/arrays_overlap_impl.rs
+++ b/src/trino/arrays_overlap_impl.rs
@@ -50,13 +50,14 @@ fn arrays_overlap_array_3_array_3_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct arrays_overlap_array_3_array_3Func {
     signature: Signature,
 }
 
 impl arrays_overlap_array_3_array_3Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for arrays_overlap_array_3_array_3Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         arrays_overlap_array_3_array_3_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for arrays_overlap_array_3_array_3Func {
         arrays_overlap_array_3_array_3_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         arrays_overlap_array_3_array_3_simplify(args, info)
     }
+
 }

--- a/src/trino/asin_impl.rs
+++ b/src/trino/asin_impl.rs
@@ -47,13 +47,14 @@ fn asin_double_simplify(args: Vec<Expr>, _info: &dyn SimplifyInfo) -> Result<Exp
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct asin_doubleFunc {
     signature: Signature,
 }
 
 impl asin_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -72,6 +73,7 @@ impl ScalarUDFImpl for asin_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         asin_double_return_type(arg_types)
     }
@@ -80,7 +82,12 @@ impl ScalarUDFImpl for asin_doubleFunc {
         asin_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         asin_double_simplify(args, info)
     }
+
 }

--- a/src/trino/at_timezone_impl.rs
+++ b/src/trino/at_timezone_impl.rs
@@ -50,13 +50,14 @@ fn at_timezone_timestamp_p_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct at_timezone_timestamp_p_varcharFunc {
     signature: Signature,
 }
 
 impl at_timezone_timestamp_p_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for at_timezone_timestamp_p_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         at_timezone_timestamp_p_varchar_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for at_timezone_timestamp_p_varcharFunc {
         at_timezone_timestamp_p_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         at_timezone_timestamp_p_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/atan2_impl.rs
+++ b/src/trino/atan2_impl.rs
@@ -50,13 +50,14 @@ fn atan2_double_double_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct atan2_double_doubleFunc {
     signature: Signature,
 }
 
 impl atan2_double_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for atan2_double_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         atan2_double_double_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for atan2_double_doubleFunc {
         atan2_double_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         atan2_double_double_simplify(args, info)
     }
+
 }

--- a/src/trino/atan_impl.rs
+++ b/src/trino/atan_impl.rs
@@ -47,13 +47,14 @@ fn atan_double_simplify(args: Vec<Expr>, _info: &dyn SimplifyInfo) -> Result<Exp
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct atan_doubleFunc {
     signature: Signature,
 }
 
 impl atan_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -72,6 +73,7 @@ impl ScalarUDFImpl for atan_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         atan_double_return_type(arg_types)
     }
@@ -80,7 +82,12 @@ impl ScalarUDFImpl for atan_doubleFunc {
         atan_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         atan_double_simplify(args, info)
     }
+
 }

--- a/src/trino/bar_impl.rs
+++ b/src/trino/bar_impl.rs
@@ -73,13 +73,14 @@ fn bar_double_bigint_color_color_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct bar_double_bigintFunc {
     signature: Signature,
 }
 
 impl bar_double_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -98,6 +99,7 @@ impl ScalarUDFImpl for bar_double_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         bar_double_bigint_return_type(arg_types)
     }
@@ -106,9 +108,14 @@ impl ScalarUDFImpl for bar_double_bigintFunc {
         bar_double_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         bar_double_bigint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -117,7 +124,7 @@ pub(super) struct bar_double_bigint_color_colorFunc {
 }
 
 impl bar_double_bigint_color_colorFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(4, Volatility::Immutable),
         }
@@ -136,6 +143,7 @@ impl ScalarUDFImpl for bar_double_bigint_color_colorFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         bar_double_bigint_color_color_return_type(arg_types)
     }
@@ -144,7 +152,12 @@ impl ScalarUDFImpl for bar_double_bigint_color_colorFunc {
         bar_double_bigint_color_color_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         bar_double_bigint_color_color_simplify(args, info)
     }
+
 }

--- a/src/trino/beta_cdf_impl.rs
+++ b/src/trino/beta_cdf_impl.rs
@@ -50,13 +50,14 @@ fn beta_cdf_double_double_double_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct beta_cdf_double_double_doubleFunc {
     signature: Signature,
 }
 
 impl beta_cdf_double_double_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(3, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for beta_cdf_double_double_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         beta_cdf_double_double_double_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for beta_cdf_double_double_doubleFunc {
         beta_cdf_double_double_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         beta_cdf_double_double_double_simplify(args, info)
     }
+
 }

--- a/src/trino/bing_tile_at_impl.rs
+++ b/src/trino/bing_tile_at_impl.rs
@@ -50,13 +50,14 @@ fn bing_tile_at_double_double_bigint_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct bing_tile_at_double_double_bigintFunc {
     signature: Signature,
 }
 
 impl bing_tile_at_double_double_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(3, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for bing_tile_at_double_double_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         bing_tile_at_double_double_bigint_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for bing_tile_at_double_double_bigintFunc {
         bing_tile_at_double_double_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         bing_tile_at_double_double_bigint_simplify(args, info)
     }
+
 }

--- a/src/trino/bing_tile_coordinates_impl.rs
+++ b/src/trino/bing_tile_coordinates_impl.rs
@@ -50,13 +50,14 @@ fn bing_tile_coordinates_bingtile_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct bing_tile_coordinates_bingtileFunc {
     signature: Signature,
 }
 
 impl bing_tile_coordinates_bingtileFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for bing_tile_coordinates_bingtileFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         bing_tile_coordinates_bingtile_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for bing_tile_coordinates_bingtileFunc {
         bing_tile_coordinates_bingtile_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         bing_tile_coordinates_bingtile_simplify(args, info)
     }
+
 }

--- a/src/trino/bing_tile_impl.rs
+++ b/src/trino/bing_tile_impl.rs
@@ -73,13 +73,14 @@ fn bing_tile_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct bing_tile_bigint_bigint_bigintFunc {
     signature: Signature,
 }
 
 impl bing_tile_bigint_bigint_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(3, Volatility::Immutable),
         }
@@ -98,6 +99,7 @@ impl ScalarUDFImpl for bing_tile_bigint_bigint_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         bing_tile_bigint_bigint_bigint_return_type(arg_types)
     }
@@ -106,9 +108,14 @@ impl ScalarUDFImpl for bing_tile_bigint_bigint_bigintFunc {
         bing_tile_bigint_bigint_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         bing_tile_bigint_bigint_bigint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -117,7 +124,7 @@ pub(super) struct bing_tile_varcharFunc {
 }
 
 impl bing_tile_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -136,6 +143,7 @@ impl ScalarUDFImpl for bing_tile_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         bing_tile_varchar_return_type(arg_types)
     }
@@ -144,7 +152,12 @@ impl ScalarUDFImpl for bing_tile_varcharFunc {
         bing_tile_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         bing_tile_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/bing_tile_polygon_impl.rs
+++ b/src/trino/bing_tile_polygon_impl.rs
@@ -50,13 +50,14 @@ fn bing_tile_polygon_bingtile_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct bing_tile_polygon_bingtileFunc {
     signature: Signature,
 }
 
 impl bing_tile_polygon_bingtileFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for bing_tile_polygon_bingtileFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         bing_tile_polygon_bingtile_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for bing_tile_polygon_bingtileFunc {
         bing_tile_polygon_bingtile_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         bing_tile_polygon_bingtile_simplify(args, info)
     }
+
 }

--- a/src/trino/bing_tile_quadkey_impl.rs
+++ b/src/trino/bing_tile_quadkey_impl.rs
@@ -50,13 +50,14 @@ fn bing_tile_quadkey_bingtile_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct bing_tile_quadkey_bingtileFunc {
     signature: Signature,
 }
 
 impl bing_tile_quadkey_bingtileFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for bing_tile_quadkey_bingtileFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         bing_tile_quadkey_bingtile_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for bing_tile_quadkey_bingtileFunc {
         bing_tile_quadkey_bingtile_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         bing_tile_quadkey_bingtile_simplify(args, info)
     }
+
 }

--- a/src/trino/bing_tile_zoom_level_impl.rs
+++ b/src/trino/bing_tile_zoom_level_impl.rs
@@ -50,13 +50,14 @@ fn bing_tile_zoom_level_bingtile_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct bing_tile_zoom_level_bingtileFunc {
     signature: Signature,
 }
 
 impl bing_tile_zoom_level_bingtileFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for bing_tile_zoom_level_bingtileFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         bing_tile_zoom_level_bingtile_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for bing_tile_zoom_level_bingtileFunc {
         bing_tile_zoom_level_bingtile_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         bing_tile_zoom_level_bingtile_simplify(args, info)
     }
+
 }

--- a/src/trino/bing_tiles_around_impl.rs
+++ b/src/trino/bing_tiles_around_impl.rs
@@ -77,13 +77,14 @@ fn bing_tiles_around_double_double_bigint_double_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct bing_tiles_around_double_double_bigintFunc {
     signature: Signature,
 }
 
 impl bing_tiles_around_double_double_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(3, Volatility::Immutable),
         }
@@ -102,6 +103,7 @@ impl ScalarUDFImpl for bing_tiles_around_double_double_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         bing_tiles_around_double_double_bigint_return_type(arg_types)
     }
@@ -110,9 +112,14 @@ impl ScalarUDFImpl for bing_tiles_around_double_double_bigintFunc {
         bing_tiles_around_double_double_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         bing_tiles_around_double_double_bigint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -121,7 +128,7 @@ pub(super) struct bing_tiles_around_double_double_bigint_doubleFunc {
 }
 
 impl bing_tiles_around_double_double_bigint_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(4, Volatility::Immutable),
         }
@@ -140,6 +147,7 @@ impl ScalarUDFImpl for bing_tiles_around_double_double_bigint_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         bing_tiles_around_double_double_bigint_double_return_type(arg_types)
     }
@@ -148,7 +156,12 @@ impl ScalarUDFImpl for bing_tiles_around_double_double_bigint_doubleFunc {
         bing_tiles_around_double_double_bigint_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         bing_tiles_around_double_double_bigint_double_simplify(args, info)
     }
+
 }

--- a/src/trino/bit_count_impl.rs
+++ b/src/trino/bit_count_impl.rs
@@ -50,13 +50,14 @@ fn bit_count_bigint_bigint_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct bit_count_bigint_bigintFunc {
     signature: Signature,
 }
 
 impl bit_count_bigint_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for bit_count_bigint_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         bit_count_bigint_bigint_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for bit_count_bigint_bigintFunc {
         bit_count_bigint_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         bit_count_bigint_bigint_simplify(args, info)
     }
+
 }

--- a/src/trino/bitwise_and_impl.rs
+++ b/src/trino/bitwise_and_impl.rs
@@ -50,13 +50,14 @@ fn bitwise_and_bigint_bigint_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct bitwise_and_bigint_bigintFunc {
     signature: Signature,
 }
 
 impl bitwise_and_bigint_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for bitwise_and_bigint_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         bitwise_and_bigint_bigint_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for bitwise_and_bigint_bigintFunc {
         bitwise_and_bigint_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         bitwise_and_bigint_bigint_simplify(args, info)
     }
+
 }

--- a/src/trino/bitwise_left_shift_impl.rs
+++ b/src/trino/bitwise_left_shift_impl.rs
@@ -119,13 +119,14 @@ fn bitwise_left_shift_tinyint_bigint_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct bitwise_left_shift_bigint_bigintFunc {
     signature: Signature,
 }
 
 impl bitwise_left_shift_bigint_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -144,6 +145,7 @@ impl ScalarUDFImpl for bitwise_left_shift_bigint_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         bitwise_left_shift_bigint_bigint_return_type(arg_types)
     }
@@ -152,9 +154,14 @@ impl ScalarUDFImpl for bitwise_left_shift_bigint_bigintFunc {
         bitwise_left_shift_bigint_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         bitwise_left_shift_bigint_bigint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -163,7 +170,7 @@ pub(super) struct bitwise_left_shift_integer_bigintFunc {
 }
 
 impl bitwise_left_shift_integer_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -182,6 +189,7 @@ impl ScalarUDFImpl for bitwise_left_shift_integer_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         bitwise_left_shift_integer_bigint_return_type(arg_types)
     }
@@ -190,9 +198,14 @@ impl ScalarUDFImpl for bitwise_left_shift_integer_bigintFunc {
         bitwise_left_shift_integer_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         bitwise_left_shift_integer_bigint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -201,7 +214,7 @@ pub(super) struct bitwise_left_shift_smallint_bigintFunc {
 }
 
 impl bitwise_left_shift_smallint_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -220,6 +233,7 @@ impl ScalarUDFImpl for bitwise_left_shift_smallint_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         bitwise_left_shift_smallint_bigint_return_type(arg_types)
     }
@@ -228,9 +242,14 @@ impl ScalarUDFImpl for bitwise_left_shift_smallint_bigintFunc {
         bitwise_left_shift_smallint_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         bitwise_left_shift_smallint_bigint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -239,7 +258,7 @@ pub(super) struct bitwise_left_shift_tinyint_bigintFunc {
 }
 
 impl bitwise_left_shift_tinyint_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -258,6 +277,7 @@ impl ScalarUDFImpl for bitwise_left_shift_tinyint_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         bitwise_left_shift_tinyint_bigint_return_type(arg_types)
     }
@@ -266,7 +286,12 @@ impl ScalarUDFImpl for bitwise_left_shift_tinyint_bigintFunc {
         bitwise_left_shift_tinyint_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         bitwise_left_shift_tinyint_bigint_simplify(args, info)
     }
+
 }

--- a/src/trino/bitwise_not_impl.rs
+++ b/src/trino/bitwise_not_impl.rs
@@ -50,13 +50,14 @@ fn bitwise_not_bigint_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct bitwise_not_bigintFunc {
     signature: Signature,
 }
 
 impl bitwise_not_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for bitwise_not_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         bitwise_not_bigint_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for bitwise_not_bigintFunc {
         bitwise_not_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         bitwise_not_bigint_simplify(args, info)
     }
+
 }

--- a/src/trino/bitwise_or_impl.rs
+++ b/src/trino/bitwise_or_impl.rs
@@ -50,13 +50,14 @@ fn bitwise_or_bigint_bigint_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct bitwise_or_bigint_bigintFunc {
     signature: Signature,
 }
 
 impl bitwise_or_bigint_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for bitwise_or_bigint_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         bitwise_or_bigint_bigint_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for bitwise_or_bigint_bigintFunc {
         bitwise_or_bigint_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         bitwise_or_bigint_bigint_simplify(args, info)
     }
+
 }

--- a/src/trino/bitwise_right_shift_arithmetic_impl.rs
+++ b/src/trino/bitwise_right_shift_arithmetic_impl.rs
@@ -135,13 +135,14 @@ fn bitwise_right_shift_arithmetic_tinyint_bigint_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct bitwise_right_shift_arithmetic_bigint_bigintFunc {
     signature: Signature,
 }
 
 impl bitwise_right_shift_arithmetic_bigint_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -160,6 +161,7 @@ impl ScalarUDFImpl for bitwise_right_shift_arithmetic_bigint_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         bitwise_right_shift_arithmetic_bigint_bigint_return_type(arg_types)
     }
@@ -168,9 +170,14 @@ impl ScalarUDFImpl for bitwise_right_shift_arithmetic_bigint_bigintFunc {
         bitwise_right_shift_arithmetic_bigint_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         bitwise_right_shift_arithmetic_bigint_bigint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -179,7 +186,7 @@ pub(super) struct bitwise_right_shift_arithmetic_integer_bigintFunc {
 }
 
 impl bitwise_right_shift_arithmetic_integer_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -198,6 +205,7 @@ impl ScalarUDFImpl for bitwise_right_shift_arithmetic_integer_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         bitwise_right_shift_arithmetic_integer_bigint_return_type(arg_types)
     }
@@ -206,9 +214,14 @@ impl ScalarUDFImpl for bitwise_right_shift_arithmetic_integer_bigintFunc {
         bitwise_right_shift_arithmetic_integer_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         bitwise_right_shift_arithmetic_integer_bigint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -217,7 +230,7 @@ pub(super) struct bitwise_right_shift_arithmetic_smallint_bigintFunc {
 }
 
 impl bitwise_right_shift_arithmetic_smallint_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -236,6 +249,7 @@ impl ScalarUDFImpl for bitwise_right_shift_arithmetic_smallint_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         bitwise_right_shift_arithmetic_smallint_bigint_return_type(arg_types)
     }
@@ -244,9 +258,14 @@ impl ScalarUDFImpl for bitwise_right_shift_arithmetic_smallint_bigintFunc {
         bitwise_right_shift_arithmetic_smallint_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         bitwise_right_shift_arithmetic_smallint_bigint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -255,7 +274,7 @@ pub(super) struct bitwise_right_shift_arithmetic_tinyint_bigintFunc {
 }
 
 impl bitwise_right_shift_arithmetic_tinyint_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -274,6 +293,7 @@ impl ScalarUDFImpl for bitwise_right_shift_arithmetic_tinyint_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         bitwise_right_shift_arithmetic_tinyint_bigint_return_type(arg_types)
     }
@@ -282,7 +302,12 @@ impl ScalarUDFImpl for bitwise_right_shift_arithmetic_tinyint_bigintFunc {
         bitwise_right_shift_arithmetic_tinyint_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         bitwise_right_shift_arithmetic_tinyint_bigint_simplify(args, info)
     }
+
 }

--- a/src/trino/bitwise_right_shift_impl.rs
+++ b/src/trino/bitwise_right_shift_impl.rs
@@ -119,13 +119,14 @@ fn bitwise_right_shift_tinyint_bigint_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct bitwise_right_shift_bigint_bigintFunc {
     signature: Signature,
 }
 
 impl bitwise_right_shift_bigint_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -144,6 +145,7 @@ impl ScalarUDFImpl for bitwise_right_shift_bigint_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         bitwise_right_shift_bigint_bigint_return_type(arg_types)
     }
@@ -152,9 +154,14 @@ impl ScalarUDFImpl for bitwise_right_shift_bigint_bigintFunc {
         bitwise_right_shift_bigint_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         bitwise_right_shift_bigint_bigint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -163,7 +170,7 @@ pub(super) struct bitwise_right_shift_integer_bigintFunc {
 }
 
 impl bitwise_right_shift_integer_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -182,6 +189,7 @@ impl ScalarUDFImpl for bitwise_right_shift_integer_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         bitwise_right_shift_integer_bigint_return_type(arg_types)
     }
@@ -190,9 +198,14 @@ impl ScalarUDFImpl for bitwise_right_shift_integer_bigintFunc {
         bitwise_right_shift_integer_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         bitwise_right_shift_integer_bigint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -201,7 +214,7 @@ pub(super) struct bitwise_right_shift_smallint_bigintFunc {
 }
 
 impl bitwise_right_shift_smallint_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -220,6 +233,7 @@ impl ScalarUDFImpl for bitwise_right_shift_smallint_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         bitwise_right_shift_smallint_bigint_return_type(arg_types)
     }
@@ -228,9 +242,14 @@ impl ScalarUDFImpl for bitwise_right_shift_smallint_bigintFunc {
         bitwise_right_shift_smallint_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         bitwise_right_shift_smallint_bigint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -239,7 +258,7 @@ pub(super) struct bitwise_right_shift_tinyint_bigintFunc {
 }
 
 impl bitwise_right_shift_tinyint_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -258,6 +277,7 @@ impl ScalarUDFImpl for bitwise_right_shift_tinyint_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         bitwise_right_shift_tinyint_bigint_return_type(arg_types)
     }
@@ -266,7 +286,12 @@ impl ScalarUDFImpl for bitwise_right_shift_tinyint_bigintFunc {
         bitwise_right_shift_tinyint_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         bitwise_right_shift_tinyint_bigint_simplify(args, info)
     }
+
 }

--- a/src/trino/bitwise_xor_impl.rs
+++ b/src/trino/bitwise_xor_impl.rs
@@ -50,13 +50,14 @@ fn bitwise_xor_bigint_bigint_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct bitwise_xor_bigint_bigintFunc {
     signature: Signature,
 }
 
 impl bitwise_xor_bigint_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for bitwise_xor_bigint_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         bitwise_xor_bigint_bigint_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for bitwise_xor_bigint_bigintFunc {
         bitwise_xor_bigint_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         bitwise_xor_bigint_bigint_simplify(args, info)
     }
+
 }

--- a/src/trino/cardinality_impl.rs
+++ b/src/trino/cardinality_impl.rs
@@ -131,13 +131,14 @@ fn cardinality_setdigest_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct cardinality_array_3Func {
     signature: Signature,
 }
 
 impl cardinality_array_3Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -156,6 +157,7 @@ impl ScalarUDFImpl for cardinality_array_3Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         cardinality_array_3_return_type(arg_types)
     }
@@ -164,9 +166,14 @@ impl ScalarUDFImpl for cardinality_array_3Func {
         cardinality_array_3_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         cardinality_array_3_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -175,7 +182,7 @@ pub(super) struct cardinality_hyperloglogFunc {
 }
 
 impl cardinality_hyperloglogFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -194,6 +201,7 @@ impl ScalarUDFImpl for cardinality_hyperloglogFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         cardinality_hyperloglog_return_type(arg_types)
     }
@@ -202,9 +210,14 @@ impl ScalarUDFImpl for cardinality_hyperloglogFunc {
         cardinality_hyperloglog_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         cardinality_hyperloglog_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -213,7 +226,7 @@ pub(super) struct cardinality_map_4_5Func {
 }
 
 impl cardinality_map_4_5Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -232,6 +245,7 @@ impl ScalarUDFImpl for cardinality_map_4_5Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         cardinality_map_4_5_return_type(arg_types)
     }
@@ -240,9 +254,14 @@ impl ScalarUDFImpl for cardinality_map_4_5Func {
         cardinality_map_4_5_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         cardinality_map_4_5_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -251,7 +270,7 @@ pub(super) struct cardinality_setdigestFunc {
 }
 
 impl cardinality_setdigestFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -270,6 +289,7 @@ impl ScalarUDFImpl for cardinality_setdigestFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         cardinality_setdigest_return_type(arg_types)
     }
@@ -278,7 +298,12 @@ impl ScalarUDFImpl for cardinality_setdigestFunc {
         cardinality_setdigest_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         cardinality_setdigest_simplify(args, info)
     }
+
 }

--- a/src/trino/cbrt_impl.rs
+++ b/src/trino/cbrt_impl.rs
@@ -47,13 +47,14 @@ fn cbrt_double_simplify(args: Vec<Expr>, _info: &dyn SimplifyInfo) -> Result<Exp
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct cbrt_doubleFunc {
     signature: Signature,
 }
 
 impl cbrt_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -72,6 +73,7 @@ impl ScalarUDFImpl for cbrt_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         cbrt_double_return_type(arg_types)
     }
@@ -80,7 +82,12 @@ impl ScalarUDFImpl for cbrt_doubleFunc {
         cbrt_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         cbrt_double_simplify(args, info)
     }
+
 }

--- a/src/trino/ceil_impl.rs
+++ b/src/trino/ceil_impl.rs
@@ -162,13 +162,14 @@ fn ceil_tinyint_simplify(args: Vec<Expr>, _info: &dyn SimplifyInfo) -> Result<Ex
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct ceil_bigintFunc {
     signature: Signature,
 }
 
 impl ceil_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -187,6 +188,7 @@ impl ScalarUDFImpl for ceil_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         ceil_bigint_return_type(arg_types)
     }
@@ -195,9 +197,14 @@ impl ScalarUDFImpl for ceil_bigintFunc {
         ceil_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         ceil_bigint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -206,7 +213,7 @@ pub(super) struct ceil_decimal_p_sFunc {
 }
 
 impl ceil_decimal_p_sFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -225,6 +232,7 @@ impl ScalarUDFImpl for ceil_decimal_p_sFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         ceil_decimal_p_s_return_type(arg_types)
     }
@@ -233,9 +241,14 @@ impl ScalarUDFImpl for ceil_decimal_p_sFunc {
         ceil_decimal_p_s_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         ceil_decimal_p_s_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -244,7 +257,7 @@ pub(super) struct ceil_doubleFunc {
 }
 
 impl ceil_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -263,6 +276,7 @@ impl ScalarUDFImpl for ceil_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         ceil_double_return_type(arg_types)
     }
@@ -271,9 +285,14 @@ impl ScalarUDFImpl for ceil_doubleFunc {
         ceil_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         ceil_double_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -282,7 +301,7 @@ pub(super) struct ceil_integerFunc {
 }
 
 impl ceil_integerFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -301,6 +320,7 @@ impl ScalarUDFImpl for ceil_integerFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         ceil_integer_return_type(arg_types)
     }
@@ -309,9 +329,14 @@ impl ScalarUDFImpl for ceil_integerFunc {
         ceil_integer_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         ceil_integer_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -320,7 +345,7 @@ pub(super) struct ceil_realFunc {
 }
 
 impl ceil_realFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -339,6 +364,7 @@ impl ScalarUDFImpl for ceil_realFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         ceil_real_return_type(arg_types)
     }
@@ -347,9 +373,14 @@ impl ScalarUDFImpl for ceil_realFunc {
         ceil_real_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         ceil_real_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -358,7 +389,7 @@ pub(super) struct ceil_smallintFunc {
 }
 
 impl ceil_smallintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -377,6 +408,7 @@ impl ScalarUDFImpl for ceil_smallintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         ceil_smallint_return_type(arg_types)
     }
@@ -385,9 +417,14 @@ impl ScalarUDFImpl for ceil_smallintFunc {
         ceil_smallint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         ceil_smallint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -396,7 +433,7 @@ pub(super) struct ceil_tinyintFunc {
 }
 
 impl ceil_tinyintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -415,6 +452,7 @@ impl ScalarUDFImpl for ceil_tinyintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         ceil_tinyint_return_type(arg_types)
     }
@@ -423,7 +461,12 @@ impl ScalarUDFImpl for ceil_tinyintFunc {
         ceil_tinyint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         ceil_tinyint_simplify(args, info)
     }
+
 }

--- a/src/trino/ceiling_impl.rs
+++ b/src/trino/ceiling_impl.rs
@@ -177,13 +177,14 @@ fn ceiling_tinyint_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct ceiling_bigintFunc {
     signature: Signature,
 }
 
 impl ceiling_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -202,6 +203,7 @@ impl ScalarUDFImpl for ceiling_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         ceiling_bigint_return_type(arg_types)
     }
@@ -210,9 +212,14 @@ impl ScalarUDFImpl for ceiling_bigintFunc {
         ceiling_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         ceiling_bigint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -221,7 +228,7 @@ pub(super) struct ceiling_decimal_p_sFunc {
 }
 
 impl ceiling_decimal_p_sFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -240,6 +247,7 @@ impl ScalarUDFImpl for ceiling_decimal_p_sFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         ceiling_decimal_p_s_return_type(arg_types)
     }
@@ -248,9 +256,14 @@ impl ScalarUDFImpl for ceiling_decimal_p_sFunc {
         ceiling_decimal_p_s_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         ceiling_decimal_p_s_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -259,7 +272,7 @@ pub(super) struct ceiling_doubleFunc {
 }
 
 impl ceiling_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -278,6 +291,7 @@ impl ScalarUDFImpl for ceiling_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         ceiling_double_return_type(arg_types)
     }
@@ -286,9 +300,14 @@ impl ScalarUDFImpl for ceiling_doubleFunc {
         ceiling_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         ceiling_double_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -297,7 +316,7 @@ pub(super) struct ceiling_integerFunc {
 }
 
 impl ceiling_integerFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -316,6 +335,7 @@ impl ScalarUDFImpl for ceiling_integerFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         ceiling_integer_return_type(arg_types)
     }
@@ -324,9 +344,14 @@ impl ScalarUDFImpl for ceiling_integerFunc {
         ceiling_integer_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         ceiling_integer_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -335,7 +360,7 @@ pub(super) struct ceiling_realFunc {
 }
 
 impl ceiling_realFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -354,6 +379,7 @@ impl ScalarUDFImpl for ceiling_realFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         ceiling_real_return_type(arg_types)
     }
@@ -362,9 +388,14 @@ impl ScalarUDFImpl for ceiling_realFunc {
         ceiling_real_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         ceiling_real_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -373,7 +404,7 @@ pub(super) struct ceiling_smallintFunc {
 }
 
 impl ceiling_smallintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -392,6 +423,7 @@ impl ScalarUDFImpl for ceiling_smallintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         ceiling_smallint_return_type(arg_types)
     }
@@ -400,9 +432,14 @@ impl ScalarUDFImpl for ceiling_smallintFunc {
         ceiling_smallint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         ceiling_smallint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -411,7 +448,7 @@ pub(super) struct ceiling_tinyintFunc {
 }
 
 impl ceiling_tinyintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -430,6 +467,7 @@ impl ScalarUDFImpl for ceiling_tinyintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         ceiling_tinyint_return_type(arg_types)
     }
@@ -438,7 +476,12 @@ impl ScalarUDFImpl for ceiling_tinyintFunc {
         ceiling_tinyint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         ceiling_tinyint_simplify(args, info)
     }
+
 }

--- a/src/trino/char2hexint_impl.rs
+++ b/src/trino/char2hexint_impl.rs
@@ -50,13 +50,14 @@ fn char2hexint_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct char2hexint_varcharFunc {
     signature: Signature,
 }
 
 impl char2hexint_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for char2hexint_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         char2hexint_varchar_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for char2hexint_varcharFunc {
         char2hexint_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         char2hexint_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/chr_impl.rs
+++ b/src/trino/chr_impl.rs
@@ -47,13 +47,14 @@ fn chr_bigint_simplify(args: Vec<Expr>, _info: &dyn SimplifyInfo) -> Result<Expr
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct chr_bigintFunc {
     signature: Signature,
 }
 
 impl chr_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -72,6 +73,7 @@ impl ScalarUDFImpl for chr_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         chr_bigint_return_type(arg_types)
     }
@@ -80,7 +82,12 @@ impl ScalarUDFImpl for chr_bigintFunc {
         chr_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         chr_bigint_simplify(args, info)
     }
+
 }

--- a/src/trino/classify_impl.rs
+++ b/src/trino/classify_impl.rs
@@ -50,13 +50,14 @@ fn classify_map_bigint_double_classifier_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct classify_map_bigint_double_classifierFunc {
     signature: Signature,
 }
 
 impl classify_map_bigint_double_classifierFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for classify_map_bigint_double_classifierFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         classify_map_bigint_double_classifier_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for classify_map_bigint_double_classifierFunc {
         classify_map_bigint_double_classifier_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         classify_map_bigint_double_classifier_simplify(args, info)
     }
+
 }

--- a/src/trino/coalesce_impl.rs
+++ b/src/trino/coalesce_impl.rs
@@ -47,13 +47,14 @@ fn coalesce_1_simplify(args: Vec<Expr>, _info: &dyn SimplifyInfo) -> Result<Expr
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct coalesce_1Func {
     signature: Signature,
 }
 
 impl coalesce_1Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::variadic_equal(Volatility::Immutable),
         }
@@ -72,6 +73,7 @@ impl ScalarUDFImpl for coalesce_1Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         coalesce_1_return_type(arg_types)
     }
@@ -80,7 +82,12 @@ impl ScalarUDFImpl for coalesce_1Func {
         coalesce_1_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         coalesce_1_simplify(args, info)
     }
+
 }

--- a/src/trino/codepoint_impl.rs
+++ b/src/trino/codepoint_impl.rs
@@ -50,13 +50,14 @@ fn codepoint_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct codepoint_varcharFunc {
     signature: Signature,
 }
 
 impl codepoint_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for codepoint_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         codepoint_varchar_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for codepoint_varcharFunc {
         codepoint_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         codepoint_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/color_impl.rs
+++ b/src/trino/color_impl.rs
@@ -93,13 +93,14 @@ fn color_varchar_simplify(args: Vec<Expr>, _info: &dyn SimplifyInfo) -> Result<E
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct color_double_color_colorFunc {
     signature: Signature,
 }
 
 impl color_double_color_colorFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(3, Volatility::Immutable),
         }
@@ -118,6 +119,7 @@ impl ScalarUDFImpl for color_double_color_colorFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         color_double_color_color_return_type(arg_types)
     }
@@ -126,9 +128,14 @@ impl ScalarUDFImpl for color_double_color_colorFunc {
         color_double_color_color_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         color_double_color_color_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -137,7 +144,7 @@ pub(super) struct color_double_double_double_color_colorFunc {
 }
 
 impl color_double_double_double_color_colorFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(5, Volatility::Immutable),
         }
@@ -156,6 +163,7 @@ impl ScalarUDFImpl for color_double_double_double_color_colorFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         color_double_double_double_color_color_return_type(arg_types)
     }
@@ -164,9 +172,14 @@ impl ScalarUDFImpl for color_double_double_double_color_colorFunc {
         color_double_double_double_color_color_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         color_double_double_double_color_color_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -175,7 +188,7 @@ pub(super) struct color_varcharFunc {
 }
 
 impl color_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -194,6 +207,7 @@ impl ScalarUDFImpl for color_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         color_varchar_return_type(arg_types)
     }
@@ -202,7 +216,12 @@ impl ScalarUDFImpl for color_varcharFunc {
         color_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         color_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/combinations_impl.rs
+++ b/src/trino/combinations_impl.rs
@@ -50,13 +50,14 @@ fn combinations_array_1_bigint_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct combinations_array_1_bigintFunc {
     signature: Signature,
 }
 
 impl combinations_array_1_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for combinations_array_1_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         combinations_array_1_bigint_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for combinations_array_1_bigintFunc {
         combinations_array_1_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         combinations_array_1_bigint_simplify(args, info)
     }
+
 }

--- a/src/trino/concat_impl.rs
+++ b/src/trino/concat_impl.rs
@@ -165,13 +165,14 @@ fn concat_varbinary_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct concat_3_array_3Func {
     signature: Signature,
 }
 
 impl concat_3_array_3Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -190,6 +191,7 @@ impl ScalarUDFImpl for concat_3_array_3Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         concat_3_array_3_return_type(arg_types)
     }
@@ -198,9 +200,14 @@ impl ScalarUDFImpl for concat_3_array_3Func {
         concat_3_array_3_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         concat_3_array_3_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -209,7 +216,7 @@ pub(super) struct concat_array_3Func {
 }
 
 impl concat_array_3Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::variadic_equal(Volatility::Immutable),
         }
@@ -228,6 +235,7 @@ impl ScalarUDFImpl for concat_array_3Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         concat_array_3_return_type(arg_types)
     }
@@ -236,9 +244,14 @@ impl ScalarUDFImpl for concat_array_3Func {
         concat_array_3_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         concat_array_3_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -247,7 +260,7 @@ pub(super) struct concat_array_3_3Func {
 }
 
 impl concat_array_3_3Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -266,6 +279,7 @@ impl ScalarUDFImpl for concat_array_3_3Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         concat_array_3_3_return_type(arg_types)
     }
@@ -274,9 +288,14 @@ impl ScalarUDFImpl for concat_array_3_3Func {
         concat_array_3_3_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         concat_array_3_3_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -285,7 +304,7 @@ pub(super) struct concat_varchar_varcharFunc {
 }
 
 impl concat_varchar_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -304,6 +323,7 @@ impl ScalarUDFImpl for concat_varchar_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         concat_varchar_varchar_return_type(arg_types)
     }
@@ -312,9 +332,14 @@ impl ScalarUDFImpl for concat_varchar_varcharFunc {
         concat_varchar_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         concat_varchar_varchar_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -323,7 +348,7 @@ pub(super) struct concat_varcharFunc {
 }
 
 impl concat_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::variadic_equal(Volatility::Immutable),
         }
@@ -342,6 +367,7 @@ impl ScalarUDFImpl for concat_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         concat_varchar_return_type(arg_types)
     }
@@ -350,9 +376,14 @@ impl ScalarUDFImpl for concat_varcharFunc {
         concat_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         concat_varchar_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -361,7 +392,7 @@ pub(super) struct concat_varbinaryFunc {
 }
 
 impl concat_varbinaryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::variadic_equal(Volatility::Immutable),
         }
@@ -380,6 +411,7 @@ impl ScalarUDFImpl for concat_varbinaryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         concat_varbinary_return_type(arg_types)
     }
@@ -388,7 +420,12 @@ impl ScalarUDFImpl for concat_varbinaryFunc {
         concat_varbinary_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         concat_varbinary_simplify(args, info)
     }
+
 }

--- a/src/trino/concat_ws_impl.rs
+++ b/src/trino/concat_ws_impl.rs
@@ -73,13 +73,14 @@ fn concat_ws_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct concat_ws_varchar_array_varcharFunc {
     signature: Signature,
 }
 
 impl concat_ws_varchar_array_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -98,6 +99,7 @@ impl ScalarUDFImpl for concat_ws_varchar_array_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         concat_ws_varchar_array_varchar_return_type(arg_types)
     }
@@ -106,9 +108,14 @@ impl ScalarUDFImpl for concat_ws_varchar_array_varcharFunc {
         concat_ws_varchar_array_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         concat_ws_varchar_array_varchar_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -117,7 +124,7 @@ pub(super) struct concat_ws_varcharFunc {
 }
 
 impl concat_ws_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::variadic_equal(Volatility::Immutable),
         }
@@ -136,6 +143,7 @@ impl ScalarUDFImpl for concat_ws_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         concat_ws_varchar_return_type(arg_types)
     }
@@ -144,7 +152,12 @@ impl ScalarUDFImpl for concat_ws_varcharFunc {
         concat_ws_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         concat_ws_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/contains_impl.rs
+++ b/src/trino/contains_impl.rs
@@ -73,13 +73,14 @@ fn contains_varchar_ipaddress_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct contains_array_1_1Func {
     signature: Signature,
 }
 
 impl contains_array_1_1Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -98,6 +99,7 @@ impl ScalarUDFImpl for contains_array_1_1Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         contains_array_1_1_return_type(arg_types)
     }
@@ -106,9 +108,14 @@ impl ScalarUDFImpl for contains_array_1_1Func {
         contains_array_1_1_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         contains_array_1_1_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -117,7 +124,7 @@ pub(super) struct contains_varchar_ipaddressFunc {
 }
 
 impl contains_varchar_ipaddressFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -136,6 +143,7 @@ impl ScalarUDFImpl for contains_varchar_ipaddressFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         contains_varchar_ipaddress_return_type(arg_types)
     }
@@ -144,7 +152,12 @@ impl ScalarUDFImpl for contains_varchar_ipaddressFunc {
         contains_varchar_ipaddress_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         contains_varchar_ipaddress_simplify(args, info)
     }
+
 }

--- a/src/trino/contains_sequence_impl.rs
+++ b/src/trino/contains_sequence_impl.rs
@@ -50,13 +50,14 @@ fn contains_sequence_array_1_array_1_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct contains_sequence_array_1_array_1Func {
     signature: Signature,
 }
 
 impl contains_sequence_array_1_array_1Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for contains_sequence_array_1_array_1Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         contains_sequence_array_1_array_1_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for contains_sequence_array_1_array_1Func {
         contains_sequence_array_1_array_1_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         contains_sequence_array_1_array_1_simplify(args, info)
     }
+
 }

--- a/src/trino/cos_impl.rs
+++ b/src/trino/cos_impl.rs
@@ -47,13 +47,14 @@ fn cos_double_simplify(args: Vec<Expr>, _info: &dyn SimplifyInfo) -> Result<Expr
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct cos_doubleFunc {
     signature: Signature,
 }
 
 impl cos_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -72,6 +73,7 @@ impl ScalarUDFImpl for cos_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         cos_double_return_type(arg_types)
     }
@@ -80,7 +82,12 @@ impl ScalarUDFImpl for cos_doubleFunc {
         cos_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         cos_double_simplify(args, info)
     }
+
 }

--- a/src/trino/cosh_impl.rs
+++ b/src/trino/cosh_impl.rs
@@ -47,13 +47,14 @@ fn cosh_double_simplify(args: Vec<Expr>, _info: &dyn SimplifyInfo) -> Result<Exp
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct cosh_doubleFunc {
     signature: Signature,
 }
 
 impl cosh_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -72,6 +73,7 @@ impl ScalarUDFImpl for cosh_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         cosh_double_return_type(arg_types)
     }
@@ -80,7 +82,12 @@ impl ScalarUDFImpl for cosh_doubleFunc {
         cosh_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         cosh_double_simplify(args, info)
     }
+
 }

--- a/src/trino/cosine_similarity_impl.rs
+++ b/src/trino/cosine_similarity_impl.rs
@@ -54,13 +54,14 @@ fn cosine_similarity_map_varchar_double_map_varchar_double_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct cosine_similarity_map_varchar_double_map_varchar_doubleFunc {
     signature: Signature,
 }
 
 impl cosine_similarity_map_varchar_double_map_varchar_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -79,6 +80,7 @@ impl ScalarUDFImpl for cosine_similarity_map_varchar_double_map_varchar_doubleFu
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         cosine_similarity_map_varchar_double_map_varchar_double_return_type(arg_types)
     }
@@ -87,7 +89,12 @@ impl ScalarUDFImpl for cosine_similarity_map_varchar_double_map_varchar_doubleFu
         cosine_similarity_map_varchar_double_map_varchar_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         cosine_similarity_map_varchar_double_map_varchar_double_simplify(args, info)
     }
+
 }

--- a/src/trino/crc32_impl.rs
+++ b/src/trino/crc32_impl.rs
@@ -50,13 +50,14 @@ fn crc32_varbinary_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct crc32_varbinaryFunc {
     signature: Signature,
 }
 
 impl crc32_varbinaryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for crc32_varbinaryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         crc32_varbinary_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for crc32_varbinaryFunc {
         crc32_varbinary_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         crc32_varbinary_simplify(args, info)
     }
+
 }

--- a/src/trino/current_catalog_impl.rs
+++ b/src/trino/current_catalog_impl.rs
@@ -50,13 +50,14 @@ fn current_catalog_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct current_catalogFunc {
     signature: Signature,
 }
 
 impl current_catalogFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(0, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for current_catalogFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         current_catalog_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for current_catalogFunc {
         current_catalog_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         current_catalog_simplify(args, info)
     }
+
 }

--- a/src/trino/current_date_impl.rs
+++ b/src/trino/current_date_impl.rs
@@ -47,13 +47,14 @@ fn current_date_simplify(args: Vec<Expr>, _info: &dyn SimplifyInfo) -> Result<Ex
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct current_dateFunc {
     signature: Signature,
 }
 
 impl current_dateFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(0, Volatility::Immutable),
         }
@@ -72,6 +73,7 @@ impl ScalarUDFImpl for current_dateFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         current_date_return_type(arg_types)
     }
@@ -80,7 +82,12 @@ impl ScalarUDFImpl for current_dateFunc {
         current_date_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         current_date_simplify(args, info)
     }
+
 }

--- a/src/trino/current_groups_impl.rs
+++ b/src/trino/current_groups_impl.rs
@@ -50,13 +50,14 @@ fn current_groups_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct current_groupsFunc {
     signature: Signature,
 }
 
 impl current_groupsFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(0, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for current_groupsFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         current_groups_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for current_groupsFunc {
         current_groups_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         current_groups_simplify(args, info)
     }
+
 }

--- a/src/trino/current_schema_impl.rs
+++ b/src/trino/current_schema_impl.rs
@@ -50,13 +50,14 @@ fn current_schema_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct current_schemaFunc {
     signature: Signature,
 }
 
 impl current_schemaFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(0, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for current_schemaFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         current_schema_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for current_schemaFunc {
         current_schema_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         current_schema_simplify(args, info)
     }
+
 }

--- a/src/trino/current_time_impl.rs
+++ b/src/trino/current_time_impl.rs
@@ -47,13 +47,14 @@ fn current_time_simplify(args: Vec<Expr>, _info: &dyn SimplifyInfo) -> Result<Ex
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct current_timeFunc {
     signature: Signature,
 }
 
 impl current_timeFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(0, Volatility::Immutable),
         }
@@ -72,6 +73,7 @@ impl ScalarUDFImpl for current_timeFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         current_time_return_type(arg_types)
     }
@@ -80,7 +82,12 @@ impl ScalarUDFImpl for current_timeFunc {
         current_time_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         current_time_simplify(args, info)
     }
+
 }

--- a/src/trino/current_timestamp_impl.rs
+++ b/src/trino/current_timestamp_impl.rs
@@ -108,13 +108,14 @@ fn current_timestamp_bigint_9_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct current_timestampFunc {
     signature: Signature,
 }
 
 impl current_timestampFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(0, Volatility::Immutable),
         }
@@ -133,6 +134,7 @@ impl ScalarUDFImpl for current_timestampFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         current_timestamp_return_type(arg_types)
     }
@@ -141,9 +143,14 @@ impl ScalarUDFImpl for current_timestampFunc {
         current_timestamp_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         current_timestamp_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -152,7 +159,7 @@ pub(super) struct current_timestamp_bigint_0Func {
 }
 
 impl current_timestamp_bigint_0Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -171,6 +178,7 @@ impl ScalarUDFImpl for current_timestamp_bigint_0Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         current_timestamp_bigint_0_return_type(arg_types)
     }
@@ -179,9 +187,14 @@ impl ScalarUDFImpl for current_timestamp_bigint_0Func {
         current_timestamp_bigint_0_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         current_timestamp_bigint_0_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -190,7 +203,7 @@ pub(super) struct current_timestamp_bigint_3Func {
 }
 
 impl current_timestamp_bigint_3Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -209,6 +222,7 @@ impl ScalarUDFImpl for current_timestamp_bigint_3Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         current_timestamp_bigint_3_return_type(arg_types)
     }
@@ -217,9 +231,14 @@ impl ScalarUDFImpl for current_timestamp_bigint_3Func {
         current_timestamp_bigint_3_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         current_timestamp_bigint_3_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -228,7 +247,7 @@ pub(super) struct current_timestamp_bigint_6Func {
 }
 
 impl current_timestamp_bigint_6Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -247,6 +266,7 @@ impl ScalarUDFImpl for current_timestamp_bigint_6Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         current_timestamp_bigint_6_return_type(arg_types)
     }
@@ -255,9 +275,14 @@ impl ScalarUDFImpl for current_timestamp_bigint_6Func {
         current_timestamp_bigint_6_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         current_timestamp_bigint_6_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -266,7 +291,7 @@ pub(super) struct current_timestamp_bigint_9Func {
 }
 
 impl current_timestamp_bigint_9Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -285,6 +310,7 @@ impl ScalarUDFImpl for current_timestamp_bigint_9Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         current_timestamp_bigint_9_return_type(arg_types)
     }
@@ -293,7 +319,12 @@ impl ScalarUDFImpl for current_timestamp_bigint_9Func {
         current_timestamp_bigint_9_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         current_timestamp_bigint_9_simplify(args, info)
     }
+
 }

--- a/src/trino/current_timezone_impl.rs
+++ b/src/trino/current_timezone_impl.rs
@@ -50,13 +50,14 @@ fn current_timezone_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct current_timezoneFunc {
     signature: Signature,
 }
 
 impl current_timezoneFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(0, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for current_timezoneFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         current_timezone_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for current_timezoneFunc {
         current_timezone_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         current_timezone_simplify(args, info)
     }
+
 }

--- a/src/trino/current_user_impl.rs
+++ b/src/trino/current_user_impl.rs
@@ -47,13 +47,14 @@ fn current_user_simplify(args: Vec<Expr>, _info: &dyn SimplifyInfo) -> Result<Ex
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct current_userFunc {
     signature: Signature,
 }
 
 impl current_userFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(0, Volatility::Immutable),
         }
@@ -72,6 +73,7 @@ impl ScalarUDFImpl for current_userFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         current_user_return_type(arg_types)
     }
@@ -80,7 +82,12 @@ impl ScalarUDFImpl for current_userFunc {
         current_user_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         current_user_simplify(args, info)
     }
+
 }

--- a/src/trino/date_add_impl.rs
+++ b/src/trino/date_add_impl.rs
@@ -96,13 +96,14 @@ fn date_add_varchar_bigint_timestamp_p_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct date_add_varchar_bigint_dateFunc {
     signature: Signature,
 }
 
 impl date_add_varchar_bigint_dateFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(3, Volatility::Immutable),
         }
@@ -121,6 +122,7 @@ impl ScalarUDFImpl for date_add_varchar_bigint_dateFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         date_add_varchar_bigint_date_return_type(arg_types)
     }
@@ -129,9 +131,14 @@ impl ScalarUDFImpl for date_add_varchar_bigint_dateFunc {
         date_add_varchar_bigint_date_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         date_add_varchar_bigint_date_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -140,7 +147,7 @@ pub(super) struct date_add_varchar_bigint_time_pFunc {
 }
 
 impl date_add_varchar_bigint_time_pFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(3, Volatility::Immutable),
         }
@@ -159,6 +166,7 @@ impl ScalarUDFImpl for date_add_varchar_bigint_time_pFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         date_add_varchar_bigint_time_p_return_type(arg_types)
     }
@@ -167,9 +175,14 @@ impl ScalarUDFImpl for date_add_varchar_bigint_time_pFunc {
         date_add_varchar_bigint_time_p_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         date_add_varchar_bigint_time_p_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -178,7 +191,7 @@ pub(super) struct date_add_varchar_bigint_timestamp_pFunc {
 }
 
 impl date_add_varchar_bigint_timestamp_pFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(3, Volatility::Immutable),
         }
@@ -197,6 +210,7 @@ impl ScalarUDFImpl for date_add_varchar_bigint_timestamp_pFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         date_add_varchar_bigint_timestamp_p_return_type(arg_types)
     }
@@ -205,7 +219,12 @@ impl ScalarUDFImpl for date_add_varchar_bigint_timestamp_pFunc {
         date_add_varchar_bigint_timestamp_p_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         date_add_varchar_bigint_timestamp_p_simplify(args, info)
     }
+
 }

--- a/src/trino/date_diff_impl.rs
+++ b/src/trino/date_diff_impl.rs
@@ -447,13 +447,14 @@ fn date_diff_varchar_timestamp_p_timestamp_p_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct date_diff_varchar_date_dateFunc {
     signature: Signature,
 }
 
 impl date_diff_varchar_date_dateFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(3, Volatility::Immutable),
         }
@@ -472,6 +473,7 @@ impl ScalarUDFImpl for date_diff_varchar_date_dateFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         date_diff_varchar_date_date_return_type(arg_types)
     }
@@ -480,9 +482,14 @@ impl ScalarUDFImpl for date_diff_varchar_date_dateFunc {
         date_diff_varchar_date_date_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         date_diff_varchar_date_date_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -491,7 +498,7 @@ pub(super) struct date_diff_varchar_time_p_time_pFunc {
 }
 
 impl date_diff_varchar_time_p_time_pFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(3, Volatility::Immutable),
         }
@@ -510,6 +517,7 @@ impl ScalarUDFImpl for date_diff_varchar_time_p_time_pFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         date_diff_varchar_time_p_time_p_return_type(arg_types)
     }
@@ -518,9 +526,14 @@ impl ScalarUDFImpl for date_diff_varchar_time_p_time_pFunc {
         date_diff_varchar_time_p_time_p_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         date_diff_varchar_time_p_time_p_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -529,7 +542,7 @@ pub(super) struct date_diff_varchar_timestamp_p_timestamp_pFunc {
 }
 
 impl date_diff_varchar_timestamp_p_timestamp_pFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(3, Volatility::Immutable),
         }
@@ -548,6 +561,7 @@ impl ScalarUDFImpl for date_diff_varchar_timestamp_p_timestamp_pFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         date_diff_varchar_timestamp_p_timestamp_p_return_type(arg_types)
     }
@@ -556,7 +570,12 @@ impl ScalarUDFImpl for date_diff_varchar_timestamp_p_timestamp_pFunc {
         date_diff_varchar_timestamp_p_timestamp_p_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         date_diff_varchar_timestamp_p_timestamp_p_simplify(args, info)
     }
+
 }

--- a/src/trino/date_format_impl.rs
+++ b/src/trino/date_format_impl.rs
@@ -50,13 +50,14 @@ fn date_format_timestamp_p_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct date_format_timestamp_p_varcharFunc {
     signature: Signature,
 }
 
 impl date_format_timestamp_p_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for date_format_timestamp_p_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         date_format_timestamp_p_varchar_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for date_format_timestamp_p_varcharFunc {
         date_format_timestamp_p_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         date_format_timestamp_p_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/date_impl.rs
+++ b/src/trino/date_impl.rs
@@ -70,13 +70,14 @@ fn date_varchar_simplify(args: Vec<Expr>, _info: &dyn SimplifyInfo) -> Result<Ex
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct date_timestamp_pFunc {
     signature: Signature,
 }
 
 impl date_timestamp_pFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -95,6 +96,7 @@ impl ScalarUDFImpl for date_timestamp_pFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         date_timestamp_p_return_type(arg_types)
     }
@@ -103,9 +105,14 @@ impl ScalarUDFImpl for date_timestamp_pFunc {
         date_timestamp_p_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         date_timestamp_p_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -114,7 +121,7 @@ pub(super) struct date_varcharFunc {
 }
 
 impl date_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -133,6 +140,7 @@ impl ScalarUDFImpl for date_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         date_varchar_return_type(arg_types)
     }
@@ -141,7 +149,12 @@ impl ScalarUDFImpl for date_varcharFunc {
         date_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         date_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/date_parse_impl.rs
+++ b/src/trino/date_parse_impl.rs
@@ -50,13 +50,14 @@ fn date_parse_varchar_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct date_parse_varchar_varcharFunc {
     signature: Signature,
 }
 
 impl date_parse_varchar_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for date_parse_varchar_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         date_parse_varchar_varchar_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for date_parse_varchar_varcharFunc {
         date_parse_varchar_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         date_parse_varchar_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/date_trunc_impl.rs
+++ b/src/trino/date_trunc_impl.rs
@@ -96,13 +96,14 @@ fn date_trunc_varchar_date_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct date_trunc_varchar_time_pFunc {
     signature: Signature,
 }
 
 impl date_trunc_varchar_time_pFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -121,6 +122,7 @@ impl ScalarUDFImpl for date_trunc_varchar_time_pFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         date_trunc_varchar_time_p_return_type(arg_types)
     }
@@ -129,9 +131,14 @@ impl ScalarUDFImpl for date_trunc_varchar_time_pFunc {
         date_trunc_varchar_time_p_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         date_trunc_varchar_time_p_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -140,7 +147,7 @@ pub(super) struct date_trunc_varchar_timestamp_pFunc {
 }
 
 impl date_trunc_varchar_timestamp_pFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -159,6 +166,7 @@ impl ScalarUDFImpl for date_trunc_varchar_timestamp_pFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         date_trunc_varchar_timestamp_p_return_type(arg_types)
     }
@@ -167,9 +175,14 @@ impl ScalarUDFImpl for date_trunc_varchar_timestamp_pFunc {
         date_trunc_varchar_timestamp_p_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         date_trunc_varchar_timestamp_p_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -178,7 +191,7 @@ pub(super) struct date_trunc_varchar_dateFunc {
 }
 
 impl date_trunc_varchar_dateFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -197,6 +210,7 @@ impl ScalarUDFImpl for date_trunc_varchar_dateFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         date_trunc_varchar_date_return_type(arg_types)
     }
@@ -205,7 +219,12 @@ impl ScalarUDFImpl for date_trunc_varchar_dateFunc {
         date_trunc_varchar_date_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         date_trunc_varchar_date_simplify(args, info)
     }
+
 }

--- a/src/trino/day_impl.rs
+++ b/src/trino/day_impl.rs
@@ -72,13 +72,14 @@ fn day_timestamp_p_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct day_dateFunc {
     signature: Signature,
 }
 
 impl day_dateFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -97,6 +98,7 @@ impl ScalarUDFImpl for day_dateFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         day_date_return_type(arg_types)
     }
@@ -105,9 +107,14 @@ impl ScalarUDFImpl for day_dateFunc {
         day_date_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         day_date_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -116,7 +123,7 @@ pub(super) struct day_intervaldaytosecondFunc {
 }
 
 impl day_intervaldaytosecondFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -135,6 +142,7 @@ impl ScalarUDFImpl for day_intervaldaytosecondFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         day_intervaldaytosecond_return_type(arg_types)
     }
@@ -143,9 +151,14 @@ impl ScalarUDFImpl for day_intervaldaytosecondFunc {
         day_intervaldaytosecond_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         day_intervaldaytosecond_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -154,7 +167,7 @@ pub(super) struct day_timestamp_pFunc {
 }
 
 impl day_timestamp_pFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -173,6 +186,7 @@ impl ScalarUDFImpl for day_timestamp_pFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         day_timestamp_p_return_type(arg_types)
     }
@@ -181,7 +195,12 @@ impl ScalarUDFImpl for day_timestamp_pFunc {
         day_timestamp_p_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         day_timestamp_p_simplify(args, info)
     }
+
 }

--- a/src/trino/day_of_month_impl.rs
+++ b/src/trino/day_of_month_impl.rs
@@ -83,13 +83,14 @@ fn day_of_month_timestamp_p_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct day_of_month_dateFunc {
     signature: Signature,
 }
 
 impl day_of_month_dateFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -108,6 +109,7 @@ impl ScalarUDFImpl for day_of_month_dateFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         day_of_month_date_return_type(arg_types)
     }
@@ -116,9 +118,14 @@ impl ScalarUDFImpl for day_of_month_dateFunc {
         day_of_month_date_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         day_of_month_date_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -127,7 +134,7 @@ pub(super) struct day_of_month_intervaldaytosecondFunc {
 }
 
 impl day_of_month_intervaldaytosecondFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -146,6 +153,7 @@ impl ScalarUDFImpl for day_of_month_intervaldaytosecondFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         day_of_month_intervaldaytosecond_return_type(arg_types)
     }
@@ -154,9 +162,14 @@ impl ScalarUDFImpl for day_of_month_intervaldaytosecondFunc {
         day_of_month_intervaldaytosecond_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         day_of_month_intervaldaytosecond_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -165,7 +178,7 @@ pub(super) struct day_of_month_timestamp_pFunc {
 }
 
 impl day_of_month_timestamp_pFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -184,6 +197,7 @@ impl ScalarUDFImpl for day_of_month_timestamp_pFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         day_of_month_timestamp_p_return_type(arg_types)
     }
@@ -192,7 +206,12 @@ impl ScalarUDFImpl for day_of_month_timestamp_pFunc {
         day_of_month_timestamp_p_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         day_of_month_timestamp_p_simplify(args, info)
     }
+
 }

--- a/src/trino/day_of_week_impl.rs
+++ b/src/trino/day_of_week_impl.rs
@@ -58,13 +58,14 @@ fn day_of_week_timestamp_p_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct day_of_week_dateFunc {
     signature: Signature,
 }
 
 impl day_of_week_dateFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -83,6 +84,7 @@ impl ScalarUDFImpl for day_of_week_dateFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         day_of_week_date_return_type(arg_types)
     }
@@ -91,9 +93,14 @@ impl ScalarUDFImpl for day_of_week_dateFunc {
         day_of_week_date_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         day_of_week_date_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -102,7 +109,7 @@ pub(super) struct day_of_week_timestamp_pFunc {
 }
 
 impl day_of_week_timestamp_pFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -121,6 +128,7 @@ impl ScalarUDFImpl for day_of_week_timestamp_pFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         day_of_week_timestamp_p_return_type(arg_types)
     }
@@ -129,7 +137,12 @@ impl ScalarUDFImpl for day_of_week_timestamp_pFunc {
         day_of_week_timestamp_p_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         day_of_week_timestamp_p_simplify(args, info)
     }
+
 }

--- a/src/trino/day_of_year_impl.rs
+++ b/src/trino/day_of_year_impl.rs
@@ -59,13 +59,14 @@ fn day_of_year_timestamp_p_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct day_of_year_dateFunc {
     signature: Signature,
 }
 
 impl day_of_year_dateFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -84,6 +85,7 @@ impl ScalarUDFImpl for day_of_year_dateFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         day_of_year_date_return_type(arg_types)
     }
@@ -92,9 +94,14 @@ impl ScalarUDFImpl for day_of_year_dateFunc {
         day_of_year_date_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         day_of_year_date_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -103,7 +110,7 @@ pub(super) struct day_of_year_timestamp_pFunc {
 }
 
 impl day_of_year_timestamp_pFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -122,6 +129,7 @@ impl ScalarUDFImpl for day_of_year_timestamp_pFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         day_of_year_timestamp_p_return_type(arg_types)
     }
@@ -130,7 +138,12 @@ impl ScalarUDFImpl for day_of_year_timestamp_pFunc {
         day_of_year_timestamp_p_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         day_of_year_timestamp_p_simplify(args, info)
     }
+
 }

--- a/src/trino/degrees_impl.rs
+++ b/src/trino/degrees_impl.rs
@@ -50,13 +50,14 @@ fn degrees_double_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct degrees_doubleFunc {
     signature: Signature,
 }
 
 impl degrees_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for degrees_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         degrees_double_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for degrees_doubleFunc {
         degrees_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         degrees_double_simplify(args, info)
     }
+
 }

--- a/src/trino/dow_impl.rs
+++ b/src/trino/dow_impl.rs
@@ -55,13 +55,14 @@ fn dow_timestamp_p_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct dow_dateFunc {
     signature: Signature,
 }
 
 impl dow_dateFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -80,6 +81,7 @@ impl ScalarUDFImpl for dow_dateFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         dow_date_return_type(arg_types)
     }
@@ -88,9 +90,14 @@ impl ScalarUDFImpl for dow_dateFunc {
         dow_date_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         dow_date_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -99,7 +106,7 @@ pub(super) struct dow_timestamp_pFunc {
 }
 
 impl dow_timestamp_pFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -118,6 +125,7 @@ impl ScalarUDFImpl for dow_timestamp_pFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         dow_timestamp_p_return_type(arg_types)
     }
@@ -126,7 +134,12 @@ impl ScalarUDFImpl for dow_timestamp_pFunc {
         dow_timestamp_p_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         dow_timestamp_p_simplify(args, info)
     }
+
 }

--- a/src/trino/doy_impl.rs
+++ b/src/trino/doy_impl.rs
@@ -56,13 +56,14 @@ fn doy_timestamp_p_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct doy_dateFunc {
     signature: Signature,
 }
 
 impl doy_dateFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -81,6 +82,7 @@ impl ScalarUDFImpl for doy_dateFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         doy_date_return_type(arg_types)
     }
@@ -89,9 +91,14 @@ impl ScalarUDFImpl for doy_dateFunc {
         doy_date_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         doy_date_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -100,7 +107,7 @@ pub(super) struct doy_timestamp_pFunc {
 }
 
 impl doy_timestamp_pFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -119,6 +126,7 @@ impl ScalarUDFImpl for doy_timestamp_pFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         doy_timestamp_p_return_type(arg_types)
     }
@@ -127,7 +135,12 @@ impl ScalarUDFImpl for doy_timestamp_pFunc {
         doy_timestamp_p_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         doy_timestamp_p_simplify(args, info)
     }
+
 }

--- a/src/trino/e_impl.rs
+++ b/src/trino/e_impl.rs
@@ -47,13 +47,14 @@ fn e_simplify(args: Vec<Expr>, _info: &dyn SimplifyInfo) -> Result<ExprSimplifyR
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct eFunc {
     signature: Signature,
 }
 
 impl eFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(0, Volatility::Immutable),
         }
@@ -72,6 +73,7 @@ impl ScalarUDFImpl for eFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         e_return_type(arg_types)
     }
@@ -80,7 +82,12 @@ impl ScalarUDFImpl for eFunc {
         e_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         e_simplify(args, info)
     }
+
 }

--- a/src/trino/element_at_impl.rs
+++ b/src/trino/element_at_impl.rs
@@ -73,13 +73,14 @@ fn element_at_array_3_bigint_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct element_at_map_4_5_4Func {
     signature: Signature,
 }
 
 impl element_at_map_4_5_4Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -98,6 +99,7 @@ impl ScalarUDFImpl for element_at_map_4_5_4Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         element_at_map_4_5_4_return_type(arg_types)
     }
@@ -106,9 +108,14 @@ impl ScalarUDFImpl for element_at_map_4_5_4Func {
         element_at_map_4_5_4_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         element_at_map_4_5_4_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -117,7 +124,7 @@ pub(super) struct element_at_array_3_bigintFunc {
 }
 
 impl element_at_array_3_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -136,6 +143,7 @@ impl ScalarUDFImpl for element_at_array_3_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         element_at_array_3_bigint_return_type(arg_types)
     }
@@ -144,7 +152,12 @@ impl ScalarUDFImpl for element_at_array_3_bigintFunc {
         element_at_array_3_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         element_at_array_3_bigint_simplify(args, info)
     }
+
 }

--- a/src/trino/empty_approx_set_impl.rs
+++ b/src/trino/empty_approx_set_impl.rs
@@ -50,13 +50,14 @@ fn empty_approx_set_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct empty_approx_setFunc {
     signature: Signature,
 }
 
 impl empty_approx_setFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(0, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for empty_approx_setFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         empty_approx_set_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for empty_approx_setFunc {
         empty_approx_set_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         empty_approx_set_simplify(args, info)
     }
+
 }

--- a/src/trino/exp_impl.rs
+++ b/src/trino/exp_impl.rs
@@ -47,13 +47,14 @@ fn exp_double_simplify(args: Vec<Expr>, _info: &dyn SimplifyInfo) -> Result<Expr
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct exp_doubleFunc {
     signature: Signature,
 }
 
 impl exp_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -72,6 +73,7 @@ impl ScalarUDFImpl for exp_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         exp_double_return_type(arg_types)
     }
@@ -80,7 +82,12 @@ impl ScalarUDFImpl for exp_doubleFunc {
         exp_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         exp_double_simplify(args, info)
     }
+
 }

--- a/src/trino/features_impl.rs
+++ b/src/trino/features_impl.rs
@@ -281,13 +281,14 @@ fn features_double_double_double_double_double_double_double_double_double_doubl
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct features_doubleFunc {
     signature: Signature,
 }
 
 impl features_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -306,6 +307,7 @@ impl ScalarUDFImpl for features_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         features_double_return_type(arg_types)
     }
@@ -314,9 +316,14 @@ impl ScalarUDFImpl for features_doubleFunc {
         features_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         features_double_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -325,7 +332,7 @@ pub(super) struct features_double_doubleFunc {
 }
 
 impl features_double_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -344,6 +351,7 @@ impl ScalarUDFImpl for features_double_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         features_double_double_return_type(arg_types)
     }
@@ -352,9 +360,14 @@ impl ScalarUDFImpl for features_double_doubleFunc {
         features_double_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         features_double_double_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -363,7 +376,7 @@ pub(super) struct features_double_double_doubleFunc {
 }
 
 impl features_double_double_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(3, Volatility::Immutable),
         }
@@ -382,6 +395,7 @@ impl ScalarUDFImpl for features_double_double_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         features_double_double_double_return_type(arg_types)
     }
@@ -390,9 +404,14 @@ impl ScalarUDFImpl for features_double_double_doubleFunc {
         features_double_double_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         features_double_double_double_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -401,7 +420,7 @@ pub(super) struct features_double_double_double_doubleFunc {
 }
 
 impl features_double_double_double_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(4, Volatility::Immutable),
         }
@@ -420,6 +439,7 @@ impl ScalarUDFImpl for features_double_double_double_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         features_double_double_double_double_return_type(arg_types)
     }
@@ -428,9 +448,14 @@ impl ScalarUDFImpl for features_double_double_double_doubleFunc {
         features_double_double_double_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         features_double_double_double_double_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -439,7 +464,7 @@ pub(super) struct features_double_double_double_double_doubleFunc {
 }
 
 impl features_double_double_double_double_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(5, Volatility::Immutable),
         }
@@ -458,6 +483,7 @@ impl ScalarUDFImpl for features_double_double_double_double_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         features_double_double_double_double_double_return_type(arg_types)
     }
@@ -466,9 +492,14 @@ impl ScalarUDFImpl for features_double_double_double_double_doubleFunc {
         features_double_double_double_double_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         features_double_double_double_double_double_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -477,7 +508,7 @@ pub(super) struct features_double_double_double_double_double_doubleFunc {
 }
 
 impl features_double_double_double_double_double_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(6, Volatility::Immutable),
         }
@@ -496,6 +527,7 @@ impl ScalarUDFImpl for features_double_double_double_double_double_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         features_double_double_double_double_double_double_return_type(arg_types)
     }
@@ -504,9 +536,14 @@ impl ScalarUDFImpl for features_double_double_double_double_double_doubleFunc {
         features_double_double_double_double_double_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         features_double_double_double_double_double_double_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -515,7 +552,7 @@ pub(super) struct features_double_double_double_double_double_double_doubleFunc 
 }
 
 impl features_double_double_double_double_double_double_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(7, Volatility::Immutable),
         }
@@ -534,6 +571,7 @@ impl ScalarUDFImpl for features_double_double_double_double_double_double_double
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         features_double_double_double_double_double_double_double_return_type(arg_types)
     }
@@ -542,9 +580,14 @@ impl ScalarUDFImpl for features_double_double_double_double_double_double_double
         features_double_double_double_double_double_double_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         features_double_double_double_double_double_double_double_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -553,7 +596,7 @@ pub(super) struct features_double_double_double_double_double_double_double_doub
 }
 
 impl features_double_double_double_double_double_double_double_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(8, Volatility::Immutable),
         }
@@ -572,6 +615,7 @@ impl ScalarUDFImpl for features_double_double_double_double_double_double_double
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         features_double_double_double_double_double_double_double_double_return_type(arg_types)
     }
@@ -580,9 +624,14 @@ impl ScalarUDFImpl for features_double_double_double_double_double_double_double
         features_double_double_double_double_double_double_double_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         features_double_double_double_double_double_double_double_double_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -591,7 +640,7 @@ pub(super) struct features_double_double_double_double_double_double_double_doub
 }
 
 impl features_double_double_double_double_double_double_double_double_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(9, Volatility::Immutable),
         }
@@ -610,38 +659,39 @@ impl ScalarUDFImpl for features_double_double_double_double_double_double_double
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
-        features_double_double_double_double_double_double_double_double_double_return_type(
-            arg_types,
-        )
+        features_double_double_double_double_double_double_double_double_double_return_type(arg_types)
     }
 
     fn invoke(&self, args: &[ColumnarValue]) -> Result<ColumnarValue> {
         features_double_double_double_double_double_double_double_double_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         features_double_double_double_double_double_double_double_double_double_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
-pub(super) struct features_double_double_double_double_double_double_double_double_double_doubleFunc
-{
+pub(super) struct features_double_double_double_double_double_double_double_double_double_doubleFunc {
     signature: Signature,
 }
 
 impl features_double_double_double_double_double_double_double_double_double_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(10, Volatility::Immutable),
         }
     }
 }
 
-impl ScalarUDFImpl
-    for features_double_double_double_double_double_double_double_double_double_doubleFunc
-{
+impl ScalarUDFImpl for features_double_double_double_double_double_double_double_double_double_doubleFunc {
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -653,19 +703,21 @@ impl ScalarUDFImpl
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
-        features_double_double_double_double_double_double_double_double_double_double_return_type(
-            arg_types,
-        )
+        features_double_double_double_double_double_double_double_double_double_double_return_type(arg_types)
     }
 
     fn invoke(&self, args: &[ColumnarValue]) -> Result<ColumnarValue> {
         features_double_double_double_double_double_double_double_double_double_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
-        features_double_double_double_double_double_double_double_double_double_double_simplify(
-            args, info,
-        )
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
+        features_double_double_double_double_double_double_double_double_double_double_simplify(args, info)
     }
+
 }

--- a/src/trino/filter_impl.rs
+++ b/src/trino/filter_impl.rs
@@ -50,13 +50,14 @@ fn filter_array_1_function_1_boolean_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct filter_array_1_function_1_booleanFunc {
     signature: Signature,
 }
 
 impl filter_array_1_function_1_booleanFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for filter_array_1_function_1_booleanFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         filter_array_1_function_1_boolean_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for filter_array_1_function_1_booleanFunc {
         filter_array_1_function_1_boolean_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         filter_array_1_function_1_boolean_simplify(args, info)
     }
+
 }

--- a/src/trino/flatten_impl.rs
+++ b/src/trino/flatten_impl.rs
@@ -50,13 +50,14 @@ fn flatten_array_array_3_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct flatten_array_array_3Func {
     signature: Signature,
 }
 
 impl flatten_array_array_3Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for flatten_array_array_3Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         flatten_array_array_3_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for flatten_array_array_3Func {
         flatten_array_array_3_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         flatten_array_array_3_simplify(args, info)
     }
+
 }

--- a/src/trino/floor_impl.rs
+++ b/src/trino/floor_impl.rs
@@ -165,13 +165,14 @@ fn floor_tinyint_simplify(args: Vec<Expr>, _info: &dyn SimplifyInfo) -> Result<E
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct floor_bigintFunc {
     signature: Signature,
 }
 
 impl floor_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -190,6 +191,7 @@ impl ScalarUDFImpl for floor_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         floor_bigint_return_type(arg_types)
     }
@@ -198,9 +200,14 @@ impl ScalarUDFImpl for floor_bigintFunc {
         floor_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         floor_bigint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -209,7 +216,7 @@ pub(super) struct floor_decimal_p_sFunc {
 }
 
 impl floor_decimal_p_sFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -228,6 +235,7 @@ impl ScalarUDFImpl for floor_decimal_p_sFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         floor_decimal_p_s_return_type(arg_types)
     }
@@ -236,9 +244,14 @@ impl ScalarUDFImpl for floor_decimal_p_sFunc {
         floor_decimal_p_s_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         floor_decimal_p_s_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -247,7 +260,7 @@ pub(super) struct floor_doubleFunc {
 }
 
 impl floor_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -266,6 +279,7 @@ impl ScalarUDFImpl for floor_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         floor_double_return_type(arg_types)
     }
@@ -274,9 +288,14 @@ impl ScalarUDFImpl for floor_doubleFunc {
         floor_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         floor_double_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -285,7 +304,7 @@ pub(super) struct floor_integerFunc {
 }
 
 impl floor_integerFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -304,6 +323,7 @@ impl ScalarUDFImpl for floor_integerFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         floor_integer_return_type(arg_types)
     }
@@ -312,9 +332,14 @@ impl ScalarUDFImpl for floor_integerFunc {
         floor_integer_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         floor_integer_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -323,7 +348,7 @@ pub(super) struct floor_realFunc {
 }
 
 impl floor_realFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -342,6 +367,7 @@ impl ScalarUDFImpl for floor_realFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         floor_real_return_type(arg_types)
     }
@@ -350,9 +376,14 @@ impl ScalarUDFImpl for floor_realFunc {
         floor_real_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         floor_real_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -361,7 +392,7 @@ pub(super) struct floor_smallintFunc {
 }
 
 impl floor_smallintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -380,6 +411,7 @@ impl ScalarUDFImpl for floor_smallintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         floor_smallint_return_type(arg_types)
     }
@@ -388,9 +420,14 @@ impl ScalarUDFImpl for floor_smallintFunc {
         floor_smallint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         floor_smallint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -399,7 +436,7 @@ pub(super) struct floor_tinyintFunc {
 }
 
 impl floor_tinyintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -418,6 +455,7 @@ impl ScalarUDFImpl for floor_tinyintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         floor_tinyint_return_type(arg_types)
     }
@@ -426,7 +464,12 @@ impl ScalarUDFImpl for floor_tinyintFunc {
         floor_tinyint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         floor_tinyint_simplify(args, info)
     }
+
 }

--- a/src/trino/format_datetime_impl.rs
+++ b/src/trino/format_datetime_impl.rs
@@ -50,13 +50,14 @@ fn format_datetime_timestamp_p_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct format_datetime_timestamp_p_varcharFunc {
     signature: Signature,
 }
 
 impl format_datetime_timestamp_p_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for format_datetime_timestamp_p_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         format_datetime_timestamp_p_varchar_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for format_datetime_timestamp_p_varcharFunc {
         format_datetime_timestamp_p_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         format_datetime_timestamp_p_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/format_impl.rs
+++ b/src/trino/format_impl.rs
@@ -142,13 +142,14 @@ fn format_varchar_1_2_3_4_5_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct format_varchar_1Func {
     signature: Signature,
 }
 
 impl format_varchar_1Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -167,6 +168,7 @@ impl ScalarUDFImpl for format_varchar_1Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         format_varchar_1_return_type(arg_types)
     }
@@ -175,9 +177,14 @@ impl ScalarUDFImpl for format_varchar_1Func {
         format_varchar_1_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         format_varchar_1_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -186,7 +193,7 @@ pub(super) struct format_varchar_1_2Func {
 }
 
 impl format_varchar_1_2Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(3, Volatility::Immutable),
         }
@@ -205,6 +212,7 @@ impl ScalarUDFImpl for format_varchar_1_2Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         format_varchar_1_2_return_type(arg_types)
     }
@@ -213,9 +221,14 @@ impl ScalarUDFImpl for format_varchar_1_2Func {
         format_varchar_1_2_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         format_varchar_1_2_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -224,7 +237,7 @@ pub(super) struct format_varchar_1_2_3Func {
 }
 
 impl format_varchar_1_2_3Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(4, Volatility::Immutable),
         }
@@ -243,6 +256,7 @@ impl ScalarUDFImpl for format_varchar_1_2_3Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         format_varchar_1_2_3_return_type(arg_types)
     }
@@ -251,9 +265,14 @@ impl ScalarUDFImpl for format_varchar_1_2_3Func {
         format_varchar_1_2_3_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         format_varchar_1_2_3_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -262,7 +281,7 @@ pub(super) struct format_varchar_1_2_3_4Func {
 }
 
 impl format_varchar_1_2_3_4Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(5, Volatility::Immutable),
         }
@@ -281,6 +300,7 @@ impl ScalarUDFImpl for format_varchar_1_2_3_4Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         format_varchar_1_2_3_4_return_type(arg_types)
     }
@@ -289,9 +309,14 @@ impl ScalarUDFImpl for format_varchar_1_2_3_4Func {
         format_varchar_1_2_3_4_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         format_varchar_1_2_3_4_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -300,7 +325,7 @@ pub(super) struct format_varchar_1_2_3_4_5Func {
 }
 
 impl format_varchar_1_2_3_4_5Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(6, Volatility::Immutable),
         }
@@ -319,6 +344,7 @@ impl ScalarUDFImpl for format_varchar_1_2_3_4_5Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         format_varchar_1_2_3_4_5_return_type(arg_types)
     }
@@ -327,7 +353,12 @@ impl ScalarUDFImpl for format_varchar_1_2_3_4_5Func {
         format_varchar_1_2_3_4_5_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         format_varchar_1_2_3_4_5_simplify(args, info)
     }
+
 }

--- a/src/trino/format_number_impl.rs
+++ b/src/trino/format_number_impl.rs
@@ -73,13 +73,14 @@ fn format_number_double_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct format_number_bigintFunc {
     signature: Signature,
 }
 
 impl format_number_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -98,6 +99,7 @@ impl ScalarUDFImpl for format_number_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         format_number_bigint_return_type(arg_types)
     }
@@ -106,9 +108,14 @@ impl ScalarUDFImpl for format_number_bigintFunc {
         format_number_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         format_number_bigint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -117,7 +124,7 @@ pub(super) struct format_number_doubleFunc {
 }
 
 impl format_number_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -136,6 +143,7 @@ impl ScalarUDFImpl for format_number_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         format_number_double_return_type(arg_types)
     }
@@ -144,7 +152,12 @@ impl ScalarUDFImpl for format_number_doubleFunc {
         format_number_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         format_number_double_simplify(args, info)
     }
+
 }

--- a/src/trino/from_base32_impl.rs
+++ b/src/trino/from_base32_impl.rs
@@ -73,13 +73,14 @@ fn from_base32_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct from_base32_varbinaryFunc {
     signature: Signature,
 }
 
 impl from_base32_varbinaryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -98,6 +99,7 @@ impl ScalarUDFImpl for from_base32_varbinaryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         from_base32_varbinary_return_type(arg_types)
     }
@@ -106,9 +108,14 @@ impl ScalarUDFImpl for from_base32_varbinaryFunc {
         from_base32_varbinary_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         from_base32_varbinary_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -117,7 +124,7 @@ pub(super) struct from_base32_varcharFunc {
 }
 
 impl from_base32_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -136,6 +143,7 @@ impl ScalarUDFImpl for from_base32_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         from_base32_varchar_return_type(arg_types)
     }
@@ -144,7 +152,12 @@ impl ScalarUDFImpl for from_base32_varcharFunc {
         from_base32_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         from_base32_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/from_base64_impl.rs
+++ b/src/trino/from_base64_impl.rs
@@ -73,13 +73,14 @@ fn from_base64_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct from_base64_varbinaryFunc {
     signature: Signature,
 }
 
 impl from_base64_varbinaryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -98,6 +99,7 @@ impl ScalarUDFImpl for from_base64_varbinaryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         from_base64_varbinary_return_type(arg_types)
     }
@@ -106,9 +108,14 @@ impl ScalarUDFImpl for from_base64_varbinaryFunc {
         from_base64_varbinary_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         from_base64_varbinary_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -117,7 +124,7 @@ pub(super) struct from_base64_varcharFunc {
 }
 
 impl from_base64_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -136,6 +143,7 @@ impl ScalarUDFImpl for from_base64_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         from_base64_varchar_return_type(arg_types)
     }
@@ -144,7 +152,12 @@ impl ScalarUDFImpl for from_base64_varcharFunc {
         from_base64_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         from_base64_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/from_base64url_impl.rs
+++ b/src/trino/from_base64url_impl.rs
@@ -73,13 +73,14 @@ fn from_base64url_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct from_base64url_varbinaryFunc {
     signature: Signature,
 }
 
 impl from_base64url_varbinaryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -98,6 +99,7 @@ impl ScalarUDFImpl for from_base64url_varbinaryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         from_base64url_varbinary_return_type(arg_types)
     }
@@ -106,9 +108,14 @@ impl ScalarUDFImpl for from_base64url_varbinaryFunc {
         from_base64url_varbinary_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         from_base64url_varbinary_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -117,7 +124,7 @@ pub(super) struct from_base64url_varcharFunc {
 }
 
 impl from_base64url_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -136,6 +143,7 @@ impl ScalarUDFImpl for from_base64url_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         from_base64url_varchar_return_type(arg_types)
     }
@@ -144,7 +152,12 @@ impl ScalarUDFImpl for from_base64url_varcharFunc {
         from_base64url_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         from_base64url_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/from_base_impl.rs
+++ b/src/trino/from_base_impl.rs
@@ -50,13 +50,14 @@ fn from_base_varchar_bigint_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct from_base_varchar_bigintFunc {
     signature: Signature,
 }
 
 impl from_base_varchar_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for from_base_varchar_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         from_base_varchar_bigint_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for from_base_varchar_bigintFunc {
         from_base_varchar_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         from_base_varchar_bigint_simplify(args, info)
     }
+
 }

--- a/src/trino/from_big_endian_32_impl.rs
+++ b/src/trino/from_big_endian_32_impl.rs
@@ -50,13 +50,14 @@ fn from_big_endian_32_varbinary_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct from_big_endian_32_varbinaryFunc {
     signature: Signature,
 }
 
 impl from_big_endian_32_varbinaryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for from_big_endian_32_varbinaryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         from_big_endian_32_varbinary_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for from_big_endian_32_varbinaryFunc {
         from_big_endian_32_varbinary_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         from_big_endian_32_varbinary_simplify(args, info)
     }
+
 }

--- a/src/trino/from_big_endian_64_impl.rs
+++ b/src/trino/from_big_endian_64_impl.rs
@@ -50,13 +50,14 @@ fn from_big_endian_64_varbinary_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct from_big_endian_64_varbinaryFunc {
     signature: Signature,
 }
 
 impl from_big_endian_64_varbinaryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for from_big_endian_64_varbinaryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         from_big_endian_64_varbinary_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for from_big_endian_64_varbinaryFunc {
         from_big_endian_64_varbinary_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         from_big_endian_64_varbinary_simplify(args, info)
     }
+
 }

--- a/src/trino/from_encoded_polyline_impl.rs
+++ b/src/trino/from_encoded_polyline_impl.rs
@@ -50,13 +50,14 @@ fn from_encoded_polyline_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct from_encoded_polyline_varcharFunc {
     signature: Signature,
 }
 
 impl from_encoded_polyline_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for from_encoded_polyline_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         from_encoded_polyline_varchar_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for from_encoded_polyline_varcharFunc {
         from_encoded_polyline_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         from_encoded_polyline_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/from_geojson_geometry_impl.rs
+++ b/src/trino/from_geojson_geometry_impl.rs
@@ -50,13 +50,14 @@ fn from_geojson_geometry_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct from_geojson_geometry_varcharFunc {
     signature: Signature,
 }
 
 impl from_geojson_geometry_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for from_geojson_geometry_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         from_geojson_geometry_varchar_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for from_geojson_geometry_varcharFunc {
         from_geojson_geometry_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         from_geojson_geometry_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/from_hex_impl.rs
+++ b/src/trino/from_hex_impl.rs
@@ -73,13 +73,14 @@ fn from_hex_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct from_hex_varbinaryFunc {
     signature: Signature,
 }
 
 impl from_hex_varbinaryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -98,6 +99,7 @@ impl ScalarUDFImpl for from_hex_varbinaryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         from_hex_varbinary_return_type(arg_types)
     }
@@ -106,9 +108,14 @@ impl ScalarUDFImpl for from_hex_varbinaryFunc {
         from_hex_varbinary_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         from_hex_varbinary_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -117,7 +124,7 @@ pub(super) struct from_hex_varcharFunc {
 }
 
 impl from_hex_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -136,6 +143,7 @@ impl ScalarUDFImpl for from_hex_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         from_hex_varchar_return_type(arg_types)
     }
@@ -144,7 +152,12 @@ impl ScalarUDFImpl for from_hex_varcharFunc {
         from_hex_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         from_hex_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/from_ieee754_32_impl.rs
+++ b/src/trino/from_ieee754_32_impl.rs
@@ -50,13 +50,14 @@ fn from_ieee754_32_varbinary_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct from_ieee754_32_varbinaryFunc {
     signature: Signature,
 }
 
 impl from_ieee754_32_varbinaryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for from_ieee754_32_varbinaryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         from_ieee754_32_varbinary_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for from_ieee754_32_varbinaryFunc {
         from_ieee754_32_varbinary_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         from_ieee754_32_varbinary_simplify(args, info)
     }
+
 }

--- a/src/trino/from_ieee754_64_impl.rs
+++ b/src/trino/from_ieee754_64_impl.rs
@@ -50,13 +50,14 @@ fn from_ieee754_64_varbinary_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct from_ieee754_64_varbinaryFunc {
     signature: Signature,
 }
 
 impl from_ieee754_64_varbinaryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for from_ieee754_64_varbinaryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         from_ieee754_64_varbinary_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for from_ieee754_64_varbinaryFunc {
         from_ieee754_64_varbinary_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         from_ieee754_64_varbinary_simplify(args, info)
     }
+
 }

--- a/src/trino/from_iso8601_date_impl.rs
+++ b/src/trino/from_iso8601_date_impl.rs
@@ -50,13 +50,14 @@ fn from_iso8601_date_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct from_iso8601_date_varcharFunc {
     signature: Signature,
 }
 
 impl from_iso8601_date_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for from_iso8601_date_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         from_iso8601_date_varchar_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for from_iso8601_date_varcharFunc {
         from_iso8601_date_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         from_iso8601_date_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/from_iso8601_timestamp_impl.rs
+++ b/src/trino/from_iso8601_timestamp_impl.rs
@@ -50,13 +50,14 @@ fn from_iso8601_timestamp_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct from_iso8601_timestamp_varcharFunc {
     signature: Signature,
 }
 
 impl from_iso8601_timestamp_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for from_iso8601_timestamp_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         from_iso8601_timestamp_varchar_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for from_iso8601_timestamp_varcharFunc {
         from_iso8601_timestamp_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         from_iso8601_timestamp_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/from_iso8601_timestamp_nanos_impl.rs
+++ b/src/trino/from_iso8601_timestamp_nanos_impl.rs
@@ -50,13 +50,14 @@ fn from_iso8601_timestamp_nanos_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct from_iso8601_timestamp_nanos_varcharFunc {
     signature: Signature,
 }
 
 impl from_iso8601_timestamp_nanos_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for from_iso8601_timestamp_nanos_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         from_iso8601_timestamp_nanos_varchar_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for from_iso8601_timestamp_nanos_varcharFunc {
         from_iso8601_timestamp_nanos_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         from_iso8601_timestamp_nanos_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/from_unixtime_impl.rs
+++ b/src/trino/from_unixtime_impl.rs
@@ -104,13 +104,14 @@ fn from_unixtime_bigint_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct from_unixtime_bigintFunc {
     signature: Signature,
 }
 
 impl from_unixtime_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -129,6 +130,7 @@ impl ScalarUDFImpl for from_unixtime_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         from_unixtime_bigint_return_type(arg_types)
     }
@@ -137,9 +139,14 @@ impl ScalarUDFImpl for from_unixtime_bigintFunc {
         from_unixtime_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         from_unixtime_bigint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -148,7 +155,7 @@ pub(super) struct from_unixtime_bigint_bigint_bigintFunc {
 }
 
 impl from_unixtime_bigint_bigint_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(3, Volatility::Immutable),
         }
@@ -167,6 +174,7 @@ impl ScalarUDFImpl for from_unixtime_bigint_bigint_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         from_unixtime_bigint_bigint_bigint_return_type(arg_types)
     }
@@ -175,9 +183,14 @@ impl ScalarUDFImpl for from_unixtime_bigint_bigint_bigintFunc {
         from_unixtime_bigint_bigint_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         from_unixtime_bigint_bigint_bigint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -186,7 +199,7 @@ pub(super) struct from_unixtime_bigint_varcharFunc {
 }
 
 impl from_unixtime_bigint_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -205,6 +218,7 @@ impl ScalarUDFImpl for from_unixtime_bigint_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         from_unixtime_bigint_varchar_return_type(arg_types)
     }
@@ -213,7 +227,12 @@ impl ScalarUDFImpl for from_unixtime_bigint_varcharFunc {
         from_unixtime_bigint_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         from_unixtime_bigint_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/from_unixtime_nanos_impl.rs
+++ b/src/trino/from_unixtime_nanos_impl.rs
@@ -73,13 +73,14 @@ fn from_unixtime_nanos_decimal_p_s_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct from_unixtime_nanos_bigintFunc {
     signature: Signature,
 }
 
 impl from_unixtime_nanos_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -98,6 +99,7 @@ impl ScalarUDFImpl for from_unixtime_nanos_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         from_unixtime_nanos_bigint_return_type(arg_types)
     }
@@ -106,9 +108,14 @@ impl ScalarUDFImpl for from_unixtime_nanos_bigintFunc {
         from_unixtime_nanos_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         from_unixtime_nanos_bigint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -117,7 +124,7 @@ pub(super) struct from_unixtime_nanos_decimal_p_sFunc {
 }
 
 impl from_unixtime_nanos_decimal_p_sFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -136,6 +143,7 @@ impl ScalarUDFImpl for from_unixtime_nanos_decimal_p_sFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         from_unixtime_nanos_decimal_p_s_return_type(arg_types)
     }
@@ -144,7 +152,12 @@ impl ScalarUDFImpl for from_unixtime_nanos_decimal_p_sFunc {
         from_unixtime_nanos_decimal_p_s_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         from_unixtime_nanos_decimal_p_s_simplify(args, info)
     }
+
 }

--- a/src/trino/from_utf8_impl.rs
+++ b/src/trino/from_utf8_impl.rs
@@ -96,13 +96,14 @@ fn from_utf8_varbinary_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct from_utf8_varbinaryFunc {
     signature: Signature,
 }
 
 impl from_utf8_varbinaryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -121,6 +122,7 @@ impl ScalarUDFImpl for from_utf8_varbinaryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         from_utf8_varbinary_return_type(arg_types)
     }
@@ -129,9 +131,14 @@ impl ScalarUDFImpl for from_utf8_varbinaryFunc {
         from_utf8_varbinary_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         from_utf8_varbinary_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -140,7 +147,7 @@ pub(super) struct from_utf8_varbinary_bigintFunc {
 }
 
 impl from_utf8_varbinary_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -159,6 +166,7 @@ impl ScalarUDFImpl for from_utf8_varbinary_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         from_utf8_varbinary_bigint_return_type(arg_types)
     }
@@ -167,9 +175,14 @@ impl ScalarUDFImpl for from_utf8_varbinary_bigintFunc {
         from_utf8_varbinary_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         from_utf8_varbinary_bigint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -178,7 +191,7 @@ pub(super) struct from_utf8_varbinary_varcharFunc {
 }
 
 impl from_utf8_varbinary_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -197,6 +210,7 @@ impl ScalarUDFImpl for from_utf8_varbinary_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         from_utf8_varbinary_varchar_return_type(arg_types)
     }
@@ -205,7 +219,12 @@ impl ScalarUDFImpl for from_utf8_varbinary_varcharFunc {
         from_utf8_varbinary_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         from_utf8_varbinary_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/geometry_from_hadoop_shape_impl.rs
+++ b/src/trino/geometry_from_hadoop_shape_impl.rs
@@ -50,13 +50,14 @@ fn geometry_from_hadoop_shape_varbinary_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct geometry_from_hadoop_shape_varbinaryFunc {
     signature: Signature,
 }
 
 impl geometry_from_hadoop_shape_varbinaryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for geometry_from_hadoop_shape_varbinaryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         geometry_from_hadoop_shape_varbinary_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for geometry_from_hadoop_shape_varbinaryFunc {
         geometry_from_hadoop_shape_varbinary_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         geometry_from_hadoop_shape_varbinary_simplify(args, info)
     }
+
 }

--- a/src/trino/geometry_invalid_reason_impl.rs
+++ b/src/trino/geometry_invalid_reason_impl.rs
@@ -50,13 +50,14 @@ fn geometry_invalid_reason_geometry_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct geometry_invalid_reason_geometryFunc {
     signature: Signature,
 }
 
 impl geometry_invalid_reason_geometryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for geometry_invalid_reason_geometryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         geometry_invalid_reason_geometry_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for geometry_invalid_reason_geometryFunc {
         geometry_invalid_reason_geometry_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         geometry_invalid_reason_geometry_simplify(args, info)
     }
+
 }

--- a/src/trino/geometry_nearest_points_impl.rs
+++ b/src/trino/geometry_nearest_points_impl.rs
@@ -54,13 +54,14 @@ fn geometry_nearest_points_geometry_geometry_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct geometry_nearest_points_geometry_geometryFunc {
     signature: Signature,
 }
 
 impl geometry_nearest_points_geometry_geometryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -79,6 +80,7 @@ impl ScalarUDFImpl for geometry_nearest_points_geometry_geometryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         geometry_nearest_points_geometry_geometry_return_type(arg_types)
     }
@@ -87,7 +89,12 @@ impl ScalarUDFImpl for geometry_nearest_points_geometry_geometryFunc {
         geometry_nearest_points_geometry_geometry_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         geometry_nearest_points_geometry_geometry_simplify(args, info)
     }
+
 }

--- a/src/trino/geometry_to_bing_tiles_impl.rs
+++ b/src/trino/geometry_to_bing_tiles_impl.rs
@@ -50,13 +50,14 @@ fn geometry_to_bing_tiles_geometry_bigint_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct geometry_to_bing_tiles_geometry_bigintFunc {
     signature: Signature,
 }
 
 impl geometry_to_bing_tiles_geometry_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for geometry_to_bing_tiles_geometry_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         geometry_to_bing_tiles_geometry_bigint_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for geometry_to_bing_tiles_geometry_bigintFunc {
         geometry_to_bing_tiles_geometry_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         geometry_to_bing_tiles_geometry_bigint_simplify(args, info)
     }
+
 }

--- a/src/trino/geometry_union_impl.rs
+++ b/src/trino/geometry_union_impl.rs
@@ -50,13 +50,14 @@ fn geometry_union_array_geometry_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct geometry_union_array_geometryFunc {
     signature: Signature,
 }
 
 impl geometry_union_array_geometryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for geometry_union_array_geometryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         geometry_union_array_geometry_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for geometry_union_array_geometryFunc {
         geometry_union_array_geometry_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         geometry_union_array_geometry_simplify(args, info)
     }
+
 }

--- a/src/trino/great_circle_distance_impl.rs
+++ b/src/trino/great_circle_distance_impl.rs
@@ -54,13 +54,14 @@ fn great_circle_distance_double_double_double_double_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct great_circle_distance_double_double_double_doubleFunc {
     signature: Signature,
 }
 
 impl great_circle_distance_double_double_double_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(4, Volatility::Immutable),
         }
@@ -79,6 +80,7 @@ impl ScalarUDFImpl for great_circle_distance_double_double_double_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         great_circle_distance_double_double_double_double_return_type(arg_types)
     }
@@ -87,7 +89,12 @@ impl ScalarUDFImpl for great_circle_distance_double_double_double_doubleFunc {
         great_circle_distance_double_double_double_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         great_circle_distance_double_double_double_double_simplify(args, info)
     }
+
 }

--- a/src/trino/greatest_impl.rs
+++ b/src/trino/greatest_impl.rs
@@ -54,13 +54,14 @@ fn greatest_3_simplify(args: Vec<Expr>, _info: &dyn SimplifyInfo) -> Result<Expr
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct greatest_3Func {
     signature: Signature,
 }
 
 impl greatest_3Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::variadic_equal(Volatility::Immutable),
         }
@@ -79,6 +80,7 @@ impl ScalarUDFImpl for greatest_3Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         greatest_3_return_type(arg_types)
     }
@@ -87,7 +89,12 @@ impl ScalarUDFImpl for greatest_3Func {
         greatest_3_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         greatest_3_simplify(args, info)
     }
+
 }

--- a/src/trino/hamming_distance_impl.rs
+++ b/src/trino/hamming_distance_impl.rs
@@ -50,13 +50,14 @@ fn hamming_distance_varchar_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct hamming_distance_varchar_varcharFunc {
     signature: Signature,
 }
 
 impl hamming_distance_varchar_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for hamming_distance_varchar_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         hamming_distance_varchar_varchar_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for hamming_distance_varchar_varcharFunc {
         hamming_distance_varchar_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         hamming_distance_varchar_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/hash_counts_impl.rs
+++ b/src/trino/hash_counts_impl.rs
@@ -50,13 +50,14 @@ fn hash_counts_setdigest_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct hash_counts_setdigestFunc {
     signature: Signature,
 }
 
 impl hash_counts_setdigestFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for hash_counts_setdigestFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         hash_counts_setdigest_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for hash_counts_setdigestFunc {
         hash_counts_setdigest_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         hash_counts_setdigest_simplify(args, info)
     }
+
 }

--- a/src/trino/hmac_md5_impl.rs
+++ b/src/trino/hmac_md5_impl.rs
@@ -50,13 +50,14 @@ fn hmac_md5_varbinary_varbinary_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct hmac_md5_varbinary_varbinaryFunc {
     signature: Signature,
 }
 
 impl hmac_md5_varbinary_varbinaryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for hmac_md5_varbinary_varbinaryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         hmac_md5_varbinary_varbinary_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for hmac_md5_varbinary_varbinaryFunc {
         hmac_md5_varbinary_varbinary_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         hmac_md5_varbinary_varbinary_simplify(args, info)
     }
+
 }

--- a/src/trino/hmac_sha1_impl.rs
+++ b/src/trino/hmac_sha1_impl.rs
@@ -50,13 +50,14 @@ fn hmac_sha1_varbinary_varbinary_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct hmac_sha1_varbinary_varbinaryFunc {
     signature: Signature,
 }
 
 impl hmac_sha1_varbinary_varbinaryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for hmac_sha1_varbinary_varbinaryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         hmac_sha1_varbinary_varbinary_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for hmac_sha1_varbinary_varbinaryFunc {
         hmac_sha1_varbinary_varbinary_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         hmac_sha1_varbinary_varbinary_simplify(args, info)
     }
+
 }

--- a/src/trino/hmac_sha256_impl.rs
+++ b/src/trino/hmac_sha256_impl.rs
@@ -50,13 +50,14 @@ fn hmac_sha256_varbinary_varbinary_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct hmac_sha256_varbinary_varbinaryFunc {
     signature: Signature,
 }
 
 impl hmac_sha256_varbinary_varbinaryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for hmac_sha256_varbinary_varbinaryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         hmac_sha256_varbinary_varbinary_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for hmac_sha256_varbinary_varbinaryFunc {
         hmac_sha256_varbinary_varbinary_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         hmac_sha256_varbinary_varbinary_simplify(args, info)
     }
+
 }

--- a/src/trino/hmac_sha512_impl.rs
+++ b/src/trino/hmac_sha512_impl.rs
@@ -50,13 +50,14 @@ fn hmac_sha512_varbinary_varbinary_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct hmac_sha512_varbinary_varbinaryFunc {
     signature: Signature,
 }
 
 impl hmac_sha512_varbinary_varbinaryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for hmac_sha512_varbinary_varbinaryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         hmac_sha512_varbinary_varbinary_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for hmac_sha512_varbinary_varbinaryFunc {
         hmac_sha512_varbinary_varbinary_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         hmac_sha512_varbinary_varbinary_simplify(args, info)
     }
+
 }

--- a/src/trino/hour_impl.rs
+++ b/src/trino/hour_impl.rs
@@ -80,13 +80,14 @@ fn hour_timestamp_p_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct hour_intervaldaytosecondFunc {
     signature: Signature,
 }
 
 impl hour_intervaldaytosecondFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -105,6 +106,7 @@ impl ScalarUDFImpl for hour_intervaldaytosecondFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         hour_intervaldaytosecond_return_type(arg_types)
     }
@@ -113,9 +115,14 @@ impl ScalarUDFImpl for hour_intervaldaytosecondFunc {
         hour_intervaldaytosecond_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         hour_intervaldaytosecond_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -124,7 +131,7 @@ pub(super) struct hour_time_pFunc {
 }
 
 impl hour_time_pFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -143,6 +150,7 @@ impl ScalarUDFImpl for hour_time_pFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         hour_time_p_return_type(arg_types)
     }
@@ -151,9 +159,14 @@ impl ScalarUDFImpl for hour_time_pFunc {
         hour_time_p_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         hour_time_p_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -162,7 +175,7 @@ pub(super) struct hour_timestamp_pFunc {
 }
 
 impl hour_timestamp_pFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -181,6 +194,7 @@ impl ScalarUDFImpl for hour_timestamp_pFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         hour_timestamp_p_return_type(arg_types)
     }
@@ -189,7 +203,12 @@ impl ScalarUDFImpl for hour_timestamp_pFunc {
         hour_timestamp_p_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         hour_timestamp_p_simplify(args, info)
     }
+
 }

--- a/src/trino/human_readable_seconds_impl.rs
+++ b/src/trino/human_readable_seconds_impl.rs
@@ -50,13 +50,14 @@ fn human_readable_seconds_double_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct human_readable_seconds_doubleFunc {
     signature: Signature,
 }
 
 impl human_readable_seconds_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for human_readable_seconds_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         human_readable_seconds_double_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for human_readable_seconds_doubleFunc {
         human_readable_seconds_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         human_readable_seconds_double_simplify(args, info)
     }
+
 }

--- a/src/trino/if_impl.rs
+++ b/src/trino/if_impl.rs
@@ -49,13 +49,14 @@ fn if_boolean_1_1_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct if_boolean_1_1Func {
     signature: Signature,
 }
 
 impl if_boolean_1_1Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(3, Volatility::Immutable),
         }
@@ -74,6 +75,7 @@ impl ScalarUDFImpl for if_boolean_1_1Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         if_boolean_1_1_return_type(arg_types)
     }
@@ -82,7 +84,12 @@ impl ScalarUDFImpl for if_boolean_1_1Func {
         if_boolean_1_1_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         if_boolean_1_1_simplify(args, info)
     }
+
 }

--- a/src/trino/index_impl.rs
+++ b/src/trino/index_impl.rs
@@ -50,13 +50,14 @@ fn index_varchar_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct index_varchar_varcharFunc {
     signature: Signature,
 }
 
 impl index_varchar_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for index_varchar_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         index_varchar_varchar_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for index_varchar_varcharFunc {
         index_varchar_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         index_varchar_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/infinity_impl.rs
+++ b/src/trino/infinity_impl.rs
@@ -47,13 +47,14 @@ fn infinity_simplify(args: Vec<Expr>, _info: &dyn SimplifyInfo) -> Result<ExprSi
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct infinityFunc {
     signature: Signature,
 }
 
 impl infinityFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(0, Volatility::Immutable),
         }
@@ -72,6 +73,7 @@ impl ScalarUDFImpl for infinityFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         infinity_return_type(arg_types)
     }
@@ -80,7 +82,12 @@ impl ScalarUDFImpl for infinityFunc {
         infinity_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         infinity_simplify(args, info)
     }
+
 }

--- a/src/trino/intersection_cardinality_impl.rs
+++ b/src/trino/intersection_cardinality_impl.rs
@@ -54,13 +54,14 @@ fn intersection_cardinality_setdigest_setdigest_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct intersection_cardinality_setdigest_setdigestFunc {
     signature: Signature,
 }
 
 impl intersection_cardinality_setdigest_setdigestFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -79,6 +80,7 @@ impl ScalarUDFImpl for intersection_cardinality_setdigest_setdigestFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         intersection_cardinality_setdigest_setdigest_return_type(arg_types)
     }
@@ -87,7 +89,12 @@ impl ScalarUDFImpl for intersection_cardinality_setdigest_setdigestFunc {
         intersection_cardinality_setdigest_setdigest_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         intersection_cardinality_setdigest_setdigest_simplify(args, info)
     }
+
 }

--- a/src/trino/inverse_beta_cdf_impl.rs
+++ b/src/trino/inverse_beta_cdf_impl.rs
@@ -50,13 +50,14 @@ fn inverse_beta_cdf_double_double_double_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct inverse_beta_cdf_double_double_doubleFunc {
     signature: Signature,
 }
 
 impl inverse_beta_cdf_double_double_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(3, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for inverse_beta_cdf_double_double_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         inverse_beta_cdf_double_double_double_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for inverse_beta_cdf_double_double_doubleFunc {
         inverse_beta_cdf_double_double_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         inverse_beta_cdf_double_double_double_simplify(args, info)
     }
+
 }

--- a/src/trino/inverse_normal_cdf_impl.rs
+++ b/src/trino/inverse_normal_cdf_impl.rs
@@ -54,13 +54,14 @@ fn inverse_normal_cdf_double_double_double_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct inverse_normal_cdf_double_double_doubleFunc {
     signature: Signature,
 }
 
 impl inverse_normal_cdf_double_double_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(3, Volatility::Immutable),
         }
@@ -79,6 +80,7 @@ impl ScalarUDFImpl for inverse_normal_cdf_double_double_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         inverse_normal_cdf_double_double_double_return_type(arg_types)
     }
@@ -87,7 +89,12 @@ impl ScalarUDFImpl for inverse_normal_cdf_double_double_doubleFunc {
         inverse_normal_cdf_double_double_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         inverse_normal_cdf_double_double_double_simplify(args, info)
     }
+
 }

--- a/src/trino/is_finite_impl.rs
+++ b/src/trino/is_finite_impl.rs
@@ -50,13 +50,14 @@ fn is_finite_double_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct is_finite_doubleFunc {
     signature: Signature,
 }
 
 impl is_finite_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for is_finite_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         is_finite_double_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for is_finite_doubleFunc {
         is_finite_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         is_finite_double_simplify(args, info)
     }
+
 }

--- a/src/trino/is_infinite_impl.rs
+++ b/src/trino/is_infinite_impl.rs
@@ -50,13 +50,14 @@ fn is_infinite_double_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct is_infinite_doubleFunc {
     signature: Signature,
 }
 
 impl is_infinite_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for is_infinite_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         is_infinite_double_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for is_infinite_doubleFunc {
         is_infinite_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         is_infinite_double_simplify(args, info)
     }
+
 }

--- a/src/trino/is_json_scalar_impl.rs
+++ b/src/trino/is_json_scalar_impl.rs
@@ -73,13 +73,14 @@ fn is_json_scalar_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct is_json_scalar_jsonFunc {
     signature: Signature,
 }
 
 impl is_json_scalar_jsonFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -98,6 +99,7 @@ impl ScalarUDFImpl for is_json_scalar_jsonFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         is_json_scalar_json_return_type(arg_types)
     }
@@ -106,9 +108,14 @@ impl ScalarUDFImpl for is_json_scalar_jsonFunc {
         is_json_scalar_json_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         is_json_scalar_json_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -117,7 +124,7 @@ pub(super) struct is_json_scalar_varcharFunc {
 }
 
 impl is_json_scalar_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -136,6 +143,7 @@ impl ScalarUDFImpl for is_json_scalar_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         is_json_scalar_varchar_return_type(arg_types)
     }
@@ -144,7 +152,12 @@ impl ScalarUDFImpl for is_json_scalar_varcharFunc {
         is_json_scalar_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         is_json_scalar_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/is_nan_impl.rs
+++ b/src/trino/is_nan_impl.rs
@@ -67,13 +67,14 @@ fn is_nan_real_simplify(args: Vec<Expr>, _info: &dyn SimplifyInfo) -> Result<Exp
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct is_nan_doubleFunc {
     signature: Signature,
 }
 
 impl is_nan_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -92,6 +93,7 @@ impl ScalarUDFImpl for is_nan_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         is_nan_double_return_type(arg_types)
     }
@@ -100,9 +102,14 @@ impl ScalarUDFImpl for is_nan_doubleFunc {
         is_nan_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         is_nan_double_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -111,7 +118,7 @@ pub(super) struct is_nan_realFunc {
 }
 
 impl is_nan_realFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -130,6 +137,7 @@ impl ScalarUDFImpl for is_nan_realFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         is_nan_real_return_type(arg_types)
     }
@@ -138,7 +146,12 @@ impl ScalarUDFImpl for is_nan_realFunc {
         is_nan_real_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         is_nan_real_simplify(args, info)
     }
+
 }

--- a/src/trino/jaccard_index_impl.rs
+++ b/src/trino/jaccard_index_impl.rs
@@ -50,13 +50,14 @@ fn jaccard_index_setdigest_setdigest_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct jaccard_index_setdigest_setdigestFunc {
     signature: Signature,
 }
 
 impl jaccard_index_setdigest_setdigestFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for jaccard_index_setdigest_setdigestFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         jaccard_index_setdigest_setdigest_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for jaccard_index_setdigest_setdigestFunc {
         jaccard_index_setdigest_setdigest_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         jaccard_index_setdigest_setdigest_simplify(args, info)
     }
+
 }

--- a/src/trino/json_array_contains_impl.rs
+++ b/src/trino/json_array_contains_impl.rs
@@ -211,13 +211,14 @@ fn json_array_contains_varchar_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct json_array_contains_json_bigintFunc {
     signature: Signature,
 }
 
 impl json_array_contains_json_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -236,6 +237,7 @@ impl ScalarUDFImpl for json_array_contains_json_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         json_array_contains_json_bigint_return_type(arg_types)
     }
@@ -244,9 +246,14 @@ impl ScalarUDFImpl for json_array_contains_json_bigintFunc {
         json_array_contains_json_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         json_array_contains_json_bigint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -255,7 +262,7 @@ pub(super) struct json_array_contains_json_booleanFunc {
 }
 
 impl json_array_contains_json_booleanFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -274,6 +281,7 @@ impl ScalarUDFImpl for json_array_contains_json_booleanFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         json_array_contains_json_boolean_return_type(arg_types)
     }
@@ -282,9 +290,14 @@ impl ScalarUDFImpl for json_array_contains_json_booleanFunc {
         json_array_contains_json_boolean_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         json_array_contains_json_boolean_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -293,7 +306,7 @@ pub(super) struct json_array_contains_json_doubleFunc {
 }
 
 impl json_array_contains_json_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -312,6 +325,7 @@ impl ScalarUDFImpl for json_array_contains_json_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         json_array_contains_json_double_return_type(arg_types)
     }
@@ -320,9 +334,14 @@ impl ScalarUDFImpl for json_array_contains_json_doubleFunc {
         json_array_contains_json_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         json_array_contains_json_double_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -331,7 +350,7 @@ pub(super) struct json_array_contains_json_varcharFunc {
 }
 
 impl json_array_contains_json_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -350,6 +369,7 @@ impl ScalarUDFImpl for json_array_contains_json_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         json_array_contains_json_varchar_return_type(arg_types)
     }
@@ -358,9 +378,14 @@ impl ScalarUDFImpl for json_array_contains_json_varcharFunc {
         json_array_contains_json_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         json_array_contains_json_varchar_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -369,7 +394,7 @@ pub(super) struct json_array_contains_varchar_bigintFunc {
 }
 
 impl json_array_contains_varchar_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -388,6 +413,7 @@ impl ScalarUDFImpl for json_array_contains_varchar_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         json_array_contains_varchar_bigint_return_type(arg_types)
     }
@@ -396,9 +422,14 @@ impl ScalarUDFImpl for json_array_contains_varchar_bigintFunc {
         json_array_contains_varchar_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         json_array_contains_varchar_bigint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -407,7 +438,7 @@ pub(super) struct json_array_contains_varchar_booleanFunc {
 }
 
 impl json_array_contains_varchar_booleanFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -426,6 +457,7 @@ impl ScalarUDFImpl for json_array_contains_varchar_booleanFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         json_array_contains_varchar_boolean_return_type(arg_types)
     }
@@ -434,9 +466,14 @@ impl ScalarUDFImpl for json_array_contains_varchar_booleanFunc {
         json_array_contains_varchar_boolean_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         json_array_contains_varchar_boolean_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -445,7 +482,7 @@ pub(super) struct json_array_contains_varchar_doubleFunc {
 }
 
 impl json_array_contains_varchar_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -464,6 +501,7 @@ impl ScalarUDFImpl for json_array_contains_varchar_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         json_array_contains_varchar_double_return_type(arg_types)
     }
@@ -472,9 +510,14 @@ impl ScalarUDFImpl for json_array_contains_varchar_doubleFunc {
         json_array_contains_varchar_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         json_array_contains_varchar_double_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -483,7 +526,7 @@ pub(super) struct json_array_contains_varchar_varcharFunc {
 }
 
 impl json_array_contains_varchar_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -502,6 +545,7 @@ impl ScalarUDFImpl for json_array_contains_varchar_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         json_array_contains_varchar_varchar_return_type(arg_types)
     }
@@ -510,7 +554,12 @@ impl ScalarUDFImpl for json_array_contains_varchar_varcharFunc {
         json_array_contains_varchar_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         json_array_contains_varchar_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/json_array_get_impl.rs
+++ b/src/trino/json_array_get_impl.rs
@@ -73,13 +73,14 @@ fn json_array_get_varchar_bigint_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct json_array_get_json_bigintFunc {
     signature: Signature,
 }
 
 impl json_array_get_json_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -98,6 +99,7 @@ impl ScalarUDFImpl for json_array_get_json_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         json_array_get_json_bigint_return_type(arg_types)
     }
@@ -106,9 +108,14 @@ impl ScalarUDFImpl for json_array_get_json_bigintFunc {
         json_array_get_json_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         json_array_get_json_bigint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -117,7 +124,7 @@ pub(super) struct json_array_get_varchar_bigintFunc {
 }
 
 impl json_array_get_varchar_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -136,6 +143,7 @@ impl ScalarUDFImpl for json_array_get_varchar_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         json_array_get_varchar_bigint_return_type(arg_types)
     }
@@ -144,7 +152,12 @@ impl ScalarUDFImpl for json_array_get_varchar_bigintFunc {
         json_array_get_varchar_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         json_array_get_varchar_bigint_simplify(args, info)
     }
+
 }

--- a/src/trino/json_array_length_impl.rs
+++ b/src/trino/json_array_length_impl.rs
@@ -73,13 +73,14 @@ fn json_array_length_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct json_array_length_jsonFunc {
     signature: Signature,
 }
 
 impl json_array_length_jsonFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -98,6 +99,7 @@ impl ScalarUDFImpl for json_array_length_jsonFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         json_array_length_json_return_type(arg_types)
     }
@@ -106,9 +108,14 @@ impl ScalarUDFImpl for json_array_length_jsonFunc {
         json_array_length_json_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         json_array_length_json_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -117,7 +124,7 @@ pub(super) struct json_array_length_varcharFunc {
 }
 
 impl json_array_length_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -136,6 +143,7 @@ impl ScalarUDFImpl for json_array_length_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         json_array_length_varchar_return_type(arg_types)
     }
@@ -144,7 +152,12 @@ impl ScalarUDFImpl for json_array_length_varcharFunc {
         json_array_length_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         json_array_length_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/json_extract_impl.rs
+++ b/src/trino/json_extract_impl.rs
@@ -73,13 +73,14 @@ fn json_extract_varchar_jsonpath_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct json_extract_json_jsonpathFunc {
     signature: Signature,
 }
 
 impl json_extract_json_jsonpathFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -98,6 +99,7 @@ impl ScalarUDFImpl for json_extract_json_jsonpathFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         json_extract_json_jsonpath_return_type(arg_types)
     }
@@ -106,9 +108,14 @@ impl ScalarUDFImpl for json_extract_json_jsonpathFunc {
         json_extract_json_jsonpath_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         json_extract_json_jsonpath_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -117,7 +124,7 @@ pub(super) struct json_extract_varchar_jsonpathFunc {
 }
 
 impl json_extract_varchar_jsonpathFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -136,6 +143,7 @@ impl ScalarUDFImpl for json_extract_varchar_jsonpathFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         json_extract_varchar_jsonpath_return_type(arg_types)
     }
@@ -144,7 +152,12 @@ impl ScalarUDFImpl for json_extract_varchar_jsonpathFunc {
         json_extract_varchar_jsonpath_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         json_extract_varchar_jsonpath_simplify(args, info)
     }
+
 }

--- a/src/trino/json_extract_scalar_impl.rs
+++ b/src/trino/json_extract_scalar_impl.rs
@@ -73,13 +73,14 @@ fn json_extract_scalar_varchar_jsonpath_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct json_extract_scalar_json_jsonpathFunc {
     signature: Signature,
 }
 
 impl json_extract_scalar_json_jsonpathFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -98,6 +99,7 @@ impl ScalarUDFImpl for json_extract_scalar_json_jsonpathFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         json_extract_scalar_json_jsonpath_return_type(arg_types)
     }
@@ -106,9 +108,14 @@ impl ScalarUDFImpl for json_extract_scalar_json_jsonpathFunc {
         json_extract_scalar_json_jsonpath_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         json_extract_scalar_json_jsonpath_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -117,7 +124,7 @@ pub(super) struct json_extract_scalar_varchar_jsonpathFunc {
 }
 
 impl json_extract_scalar_varchar_jsonpathFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -136,6 +143,7 @@ impl ScalarUDFImpl for json_extract_scalar_varchar_jsonpathFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         json_extract_scalar_varchar_jsonpath_return_type(arg_types)
     }
@@ -144,7 +152,12 @@ impl ScalarUDFImpl for json_extract_scalar_varchar_jsonpathFunc {
         json_extract_scalar_varchar_jsonpath_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         json_extract_scalar_varchar_jsonpath_simplify(args, info)
     }
+
 }

--- a/src/trino/json_format_impl.rs
+++ b/src/trino/json_format_impl.rs
@@ -50,13 +50,14 @@ fn json_format_json_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct json_format_jsonFunc {
     signature: Signature,
 }
 
 impl json_format_jsonFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for json_format_jsonFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         json_format_json_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for json_format_jsonFunc {
         json_format_json_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         json_format_json_simplify(args, info)
     }
+
 }

--- a/src/trino/json_parse_impl.rs
+++ b/src/trino/json_parse_impl.rs
@@ -50,13 +50,14 @@ fn json_parse_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct json_parse_varcharFunc {
     signature: Signature,
 }
 
 impl json_parse_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for json_parse_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         json_parse_varchar_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for json_parse_varcharFunc {
         json_parse_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         json_parse_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/json_size_impl.rs
+++ b/src/trino/json_size_impl.rs
@@ -73,13 +73,14 @@ fn json_size_varchar_jsonpath_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct json_size_json_jsonpathFunc {
     signature: Signature,
 }
 
 impl json_size_json_jsonpathFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -98,6 +99,7 @@ impl ScalarUDFImpl for json_size_json_jsonpathFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         json_size_json_jsonpath_return_type(arg_types)
     }
@@ -106,9 +108,14 @@ impl ScalarUDFImpl for json_size_json_jsonpathFunc {
         json_size_json_jsonpath_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         json_size_json_jsonpath_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -117,7 +124,7 @@ pub(super) struct json_size_varchar_jsonpathFunc {
 }
 
 impl json_size_varchar_jsonpathFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -136,6 +143,7 @@ impl ScalarUDFImpl for json_size_varchar_jsonpathFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         json_size_varchar_jsonpath_return_type(arg_types)
     }
@@ -144,7 +152,12 @@ impl ScalarUDFImpl for json_size_varchar_jsonpathFunc {
         json_size_varchar_jsonpath_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         json_size_varchar_jsonpath_simplify(args, info)
     }
+
 }

--- a/src/trino/last_day_of_month_impl.rs
+++ b/src/trino/last_day_of_month_impl.rs
@@ -73,13 +73,14 @@ fn last_day_of_month_timestamp_p_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct last_day_of_month_dateFunc {
     signature: Signature,
 }
 
 impl last_day_of_month_dateFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -98,6 +99,7 @@ impl ScalarUDFImpl for last_day_of_month_dateFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         last_day_of_month_date_return_type(arg_types)
     }
@@ -106,9 +108,14 @@ impl ScalarUDFImpl for last_day_of_month_dateFunc {
         last_day_of_month_date_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         last_day_of_month_date_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -117,7 +124,7 @@ pub(super) struct last_day_of_month_timestamp_pFunc {
 }
 
 impl last_day_of_month_timestamp_pFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -136,6 +143,7 @@ impl ScalarUDFImpl for last_day_of_month_timestamp_pFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         last_day_of_month_timestamp_p_return_type(arg_types)
     }
@@ -144,7 +152,12 @@ impl ScalarUDFImpl for last_day_of_month_timestamp_pFunc {
         last_day_of_month_timestamp_p_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         last_day_of_month_timestamp_p_simplify(args, info)
     }
+
 }

--- a/src/trino/least_impl.rs
+++ b/src/trino/least_impl.rs
@@ -54,13 +54,14 @@ fn least_3_simplify(args: Vec<Expr>, _info: &dyn SimplifyInfo) -> Result<ExprSim
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct least_3Func {
     signature: Signature,
 }
 
 impl least_3Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::variadic_equal(Volatility::Immutable),
         }
@@ -79,6 +80,7 @@ impl ScalarUDFImpl for least_3Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         least_3_return_type(arg_types)
     }
@@ -87,7 +89,12 @@ impl ScalarUDFImpl for least_3Func {
         least_3_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         least_3_simplify(args, info)
     }
+
 }

--- a/src/trino/length_impl.rs
+++ b/src/trino/length_impl.rs
@@ -96,13 +96,14 @@ fn length_array_1_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct length_varcharFunc {
     signature: Signature,
 }
 
 impl length_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -121,6 +122,7 @@ impl ScalarUDFImpl for length_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         length_varchar_return_type(arg_types)
     }
@@ -129,9 +131,14 @@ impl ScalarUDFImpl for length_varcharFunc {
         length_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         length_varchar_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -140,7 +147,7 @@ pub(super) struct length_varbinaryFunc {
 }
 
 impl length_varbinaryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -159,6 +166,7 @@ impl ScalarUDFImpl for length_varbinaryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         length_varbinary_return_type(arg_types)
     }
@@ -167,45 +175,12 @@ impl ScalarUDFImpl for length_varbinaryFunc {
         length_varbinary_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         length_varbinary_simplify(args, info)
     }
-}
 
-#[derive(Debug)]
-pub(super) struct length_array_1Func {
-    signature: Signature,
-}
-
-impl length_array_1Func {
-    pub fn new() -> Self {
-        Self {
-            signature: Signature::any(1, Volatility::Immutable),
-        }
-    }
-}
-
-impl ScalarUDFImpl for length_array_1Func {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-    fn name(&self) -> &str {
-        "length"
-    }
-
-    fn signature(&self) -> &Signature {
-        &self.signature
-    }
-
-    fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
-        length_array_1_return_type(arg_types)
-    }
-
-    fn invoke(&self, args: &[ColumnarValue]) -> Result<ColumnarValue> {
-        length_array_1_invoke(args)
-    }
-
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
-        length_array_1_simplify(args, info)
-    }
 }

--- a/src/trino/length_impl.rs
+++ b/src/trino/length_impl.rs
@@ -69,33 +69,9 @@ fn length_varbinary_simplify(
     Ok(ExprSimplifyResult::Original(args))
 }
 
-fn length_array_1_invoke(_args: &[ColumnarValue]) -> Result<ColumnarValue> {
-    Err(DataFusionError::NotImplemented(format!(
-        "Not implemented {}:{}",
-        file!(),
-        line!()
-    )))
-}
-
-fn length_array_1_return_type(_arg_types: &[DataType]) -> Result<DataType> {
-    Err(DataFusionError::NotImplemented(format!(
-        "Not implemented {}:{}",
-        file!(),
-        line!()
-    )))
-}
-
-fn length_array_1_simplify(
-    args: Vec<Expr>,
-    _info: &dyn SimplifyInfo,
-) -> Result<ExprSimplifyResult> {
-    Ok(ExprSimplifyResult::Original(args))
-}
-
 // ========== Generated template below this line ==========
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
-
 
 #[derive(Debug)]
 pub(super) struct length_varcharFunc {
@@ -103,7 +79,7 @@ pub(super) struct length_varcharFunc {
 }
 
 impl length_varcharFunc {
-    pub fn new() -> Self {        
+    pub fn new() -> Self {
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -122,7 +98,6 @@ impl ScalarUDFImpl for length_varcharFunc {
         &self.signature
     }
 
-
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         length_varchar_return_type(arg_types)
     }
@@ -131,14 +106,9 @@ impl ScalarUDFImpl for length_varcharFunc {
         length_varchar_invoke(args)
     }
 
-    fn simplify(
-        &self,
-        args: Vec<Expr>,
-        info: &dyn SimplifyInfo,
-    ) -> Result<ExprSimplifyResult> {
+    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
         length_varchar_simplify(args, info)
     }
-
 }
 
 #[derive(Debug)]
@@ -147,7 +117,7 @@ pub(super) struct length_varbinaryFunc {
 }
 
 impl length_varbinaryFunc {
-    pub fn new() -> Self {        
+    pub fn new() -> Self {
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -166,7 +136,6 @@ impl ScalarUDFImpl for length_varbinaryFunc {
         &self.signature
     }
 
-
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         length_varbinary_return_type(arg_types)
     }
@@ -175,12 +144,7 @@ impl ScalarUDFImpl for length_varbinaryFunc {
         length_varbinary_invoke(args)
     }
 
-    fn simplify(
-        &self,
-        args: Vec<Expr>,
-        info: &dyn SimplifyInfo,
-    ) -> Result<ExprSimplifyResult> {
+    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
         length_varbinary_simplify(args, info)
     }
-
 }

--- a/src/trino/levenshtein_distance_impl.rs
+++ b/src/trino/levenshtein_distance_impl.rs
@@ -50,13 +50,14 @@ fn levenshtein_distance_varchar_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct levenshtein_distance_varchar_varcharFunc {
     signature: Signature,
 }
 
 impl levenshtein_distance_varchar_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for levenshtein_distance_varchar_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         levenshtein_distance_varchar_varchar_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for levenshtein_distance_varchar_varcharFunc {
         levenshtein_distance_varchar_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         levenshtein_distance_varchar_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/line_interpolate_point_impl.rs
+++ b/src/trino/line_interpolate_point_impl.rs
@@ -50,13 +50,14 @@ fn line_interpolate_point_geometry_double_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct line_interpolate_point_geometry_doubleFunc {
     signature: Signature,
 }
 
 impl line_interpolate_point_geometry_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for line_interpolate_point_geometry_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         line_interpolate_point_geometry_double_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for line_interpolate_point_geometry_doubleFunc {
         line_interpolate_point_geometry_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         line_interpolate_point_geometry_double_simplify(args, info)
     }
+
 }

--- a/src/trino/line_interpolate_points_impl.rs
+++ b/src/trino/line_interpolate_points_impl.rs
@@ -54,13 +54,14 @@ fn line_interpolate_points_geometry_double_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct line_interpolate_points_geometry_doubleFunc {
     signature: Signature,
 }
 
 impl line_interpolate_points_geometry_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -79,6 +80,7 @@ impl ScalarUDFImpl for line_interpolate_points_geometry_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         line_interpolate_points_geometry_double_return_type(arg_types)
     }
@@ -87,7 +89,12 @@ impl ScalarUDFImpl for line_interpolate_points_geometry_doubleFunc {
         line_interpolate_points_geometry_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         line_interpolate_points_geometry_double_simplify(args, info)
     }
+
 }

--- a/src/trino/line_locate_point_impl.rs
+++ b/src/trino/line_locate_point_impl.rs
@@ -50,13 +50,14 @@ fn line_locate_point_geometry_geometry_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct line_locate_point_geometry_geometryFunc {
     signature: Signature,
 }
 
 impl line_locate_point_geometry_geometryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for line_locate_point_geometry_geometryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         line_locate_point_geometry_geometry_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for line_locate_point_geometry_geometryFunc {
         line_locate_point_geometry_geometry_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         line_locate_point_geometry_geometry_simplify(args, info)
     }
+
 }

--- a/src/trino/ln_impl.rs
+++ b/src/trino/ln_impl.rs
@@ -47,13 +47,14 @@ fn ln_double_simplify(args: Vec<Expr>, _info: &dyn SimplifyInfo) -> Result<ExprS
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct ln_doubleFunc {
     signature: Signature,
 }
 
 impl ln_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -72,6 +73,7 @@ impl ScalarUDFImpl for ln_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         ln_double_return_type(arg_types)
     }
@@ -80,7 +82,12 @@ impl ScalarUDFImpl for ln_doubleFunc {
         ln_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         ln_double_simplify(args, info)
     }
+
 }

--- a/src/trino/localtime_impl.rs
+++ b/src/trino/localtime_impl.rs
@@ -39,13 +39,14 @@ fn localtime_simplify(args: Vec<Expr>, _info: &dyn SimplifyInfo) -> Result<ExprS
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct localtimeFunc {
     signature: Signature,
 }
 
 impl localtimeFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(0, Volatility::Immutable),
         }
@@ -64,6 +65,7 @@ impl ScalarUDFImpl for localtimeFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         localtime_return_type(arg_types)
     }
@@ -72,7 +74,12 @@ impl ScalarUDFImpl for localtimeFunc {
         localtime_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         localtime_simplify(args, info)
     }
+
 }

--- a/src/trino/localtimestamp_impl.rs
+++ b/src/trino/localtimestamp_impl.rs
@@ -138,13 +138,14 @@ fn localtimestamp_bigint_9_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct localtimestampFunc {
     signature: Signature,
 }
 
 impl localtimestampFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(0, Volatility::Immutable),
         }
@@ -163,6 +164,7 @@ impl ScalarUDFImpl for localtimestampFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         localtimestamp_return_type(arg_types)
     }
@@ -171,9 +173,14 @@ impl ScalarUDFImpl for localtimestampFunc {
         localtimestamp_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         localtimestamp_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -182,7 +189,7 @@ pub(super) struct localtimestamp_bigint_0Func {
 }
 
 impl localtimestamp_bigint_0Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -201,6 +208,7 @@ impl ScalarUDFImpl for localtimestamp_bigint_0Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         localtimestamp_bigint_0_return_type(arg_types)
     }
@@ -209,9 +217,14 @@ impl ScalarUDFImpl for localtimestamp_bigint_0Func {
         localtimestamp_bigint_0_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         localtimestamp_bigint_0_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -220,7 +233,7 @@ pub(super) struct localtimestamp_bigint_3Func {
 }
 
 impl localtimestamp_bigint_3Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -239,6 +252,7 @@ impl ScalarUDFImpl for localtimestamp_bigint_3Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         localtimestamp_bigint_3_return_type(arg_types)
     }
@@ -247,9 +261,14 @@ impl ScalarUDFImpl for localtimestamp_bigint_3Func {
         localtimestamp_bigint_3_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         localtimestamp_bigint_3_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -258,7 +277,7 @@ pub(super) struct localtimestamp_bigint_6Func {
 }
 
 impl localtimestamp_bigint_6Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -277,6 +296,7 @@ impl ScalarUDFImpl for localtimestamp_bigint_6Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         localtimestamp_bigint_6_return_type(arg_types)
     }
@@ -285,9 +305,14 @@ impl ScalarUDFImpl for localtimestamp_bigint_6Func {
         localtimestamp_bigint_6_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         localtimestamp_bigint_6_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -296,7 +321,7 @@ pub(super) struct localtimestamp_bigint_9Func {
 }
 
 impl localtimestamp_bigint_9Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -315,6 +340,7 @@ impl ScalarUDFImpl for localtimestamp_bigint_9Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         localtimestamp_bigint_9_return_type(arg_types)
     }
@@ -323,7 +349,12 @@ impl ScalarUDFImpl for localtimestamp_bigint_9Func {
         localtimestamp_bigint_9_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         localtimestamp_bigint_9_simplify(args, info)
     }
+
 }

--- a/src/trino/log10_impl.rs
+++ b/src/trino/log10_impl.rs
@@ -47,13 +47,14 @@ fn log10_double_simplify(args: Vec<Expr>, _info: &dyn SimplifyInfo) -> Result<Ex
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct log10_doubleFunc {
     signature: Signature,
 }
 
 impl log10_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -72,6 +73,7 @@ impl ScalarUDFImpl for log10_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         log10_double_return_type(arg_types)
     }
@@ -80,7 +82,12 @@ impl ScalarUDFImpl for log10_doubleFunc {
         log10_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         log10_double_simplify(args, info)
     }
+
 }

--- a/src/trino/log2_impl.rs
+++ b/src/trino/log2_impl.rs
@@ -47,13 +47,14 @@ fn log2_double_simplify(args: Vec<Expr>, _info: &dyn SimplifyInfo) -> Result<Exp
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct log2_doubleFunc {
     signature: Signature,
 }
 
 impl log2_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -72,6 +73,7 @@ impl ScalarUDFImpl for log2_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         log2_double_return_type(arg_types)
     }
@@ -80,7 +82,12 @@ impl ScalarUDFImpl for log2_doubleFunc {
         log2_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         log2_double_simplify(args, info)
     }
+
 }

--- a/src/trino/log_impl.rs
+++ b/src/trino/log_impl.rs
@@ -50,13 +50,14 @@ fn log_double_double_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct log_double_doubleFunc {
     signature: Signature,
 }
 
 impl log_double_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for log_double_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         log_double_double_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for log_double_doubleFunc {
         log_double_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         log_double_double_simplify(args, info)
     }
+
 }

--- a/src/trino/lower_impl.rs
+++ b/src/trino/lower_impl.rs
@@ -47,13 +47,14 @@ fn lower_varchar_simplify(args: Vec<Expr>, _info: &dyn SimplifyInfo) -> Result<E
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct lower_varcharFunc {
     signature: Signature,
 }
 
 impl lower_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -72,6 +73,7 @@ impl ScalarUDFImpl for lower_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         lower_varchar_return_type(arg_types)
     }
@@ -80,7 +82,12 @@ impl ScalarUDFImpl for lower_varcharFunc {
         lower_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         lower_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/lpad_impl.rs
+++ b/src/trino/lpad_impl.rs
@@ -73,13 +73,14 @@ fn lpad_varchar_bigint_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct lpad_varbinary_bigint_varbinaryFunc {
     signature: Signature,
 }
 
 impl lpad_varbinary_bigint_varbinaryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(3, Volatility::Immutable),
         }
@@ -98,6 +99,7 @@ impl ScalarUDFImpl for lpad_varbinary_bigint_varbinaryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         lpad_varbinary_bigint_varbinary_return_type(arg_types)
     }
@@ -106,9 +108,14 @@ impl ScalarUDFImpl for lpad_varbinary_bigint_varbinaryFunc {
         lpad_varbinary_bigint_varbinary_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         lpad_varbinary_bigint_varbinary_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -117,7 +124,7 @@ pub(super) struct lpad_varchar_bigint_varcharFunc {
 }
 
 impl lpad_varchar_bigint_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(3, Volatility::Immutable),
         }
@@ -136,6 +143,7 @@ impl ScalarUDFImpl for lpad_varchar_bigint_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         lpad_varchar_bigint_varchar_return_type(arg_types)
     }
@@ -144,7 +152,12 @@ impl ScalarUDFImpl for lpad_varchar_bigint_varcharFunc {
         lpad_varchar_bigint_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         lpad_varchar_bigint_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/ltrim_impl.rs
+++ b/src/trino/ltrim_impl.rs
@@ -70,13 +70,14 @@ fn ltrim_varchar_codepoints_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct ltrim_varcharFunc {
     signature: Signature,
 }
 
 impl ltrim_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -95,6 +96,7 @@ impl ScalarUDFImpl for ltrim_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         ltrim_varchar_return_type(arg_types)
     }
@@ -103,9 +105,14 @@ impl ScalarUDFImpl for ltrim_varcharFunc {
         ltrim_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         ltrim_varchar_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -114,7 +121,7 @@ pub(super) struct ltrim_varchar_codepointsFunc {
 }
 
 impl ltrim_varchar_codepointsFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -133,6 +140,7 @@ impl ScalarUDFImpl for ltrim_varchar_codepointsFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         ltrim_varchar_codepoints_return_type(arg_types)
     }
@@ -141,7 +149,12 @@ impl ScalarUDFImpl for ltrim_varchar_codepointsFunc {
         ltrim_varchar_codepoints_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         ltrim_varchar_codepoints_simplify(args, info)
     }
+
 }

--- a/src/trino/luhn_check_impl.rs
+++ b/src/trino/luhn_check_impl.rs
@@ -50,13 +50,14 @@ fn luhn_check_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct luhn_check_varcharFunc {
     signature: Signature,
 }
 
 impl luhn_check_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for luhn_check_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         luhn_check_varchar_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for luhn_check_varcharFunc {
         luhn_check_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         luhn_check_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/map_concat_impl.rs
+++ b/src/trino/map_concat_impl.rs
@@ -50,13 +50,14 @@ fn map_concat_map_4_5_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct map_concat_map_4_5Func {
     signature: Signature,
 }
 
 impl map_concat_map_4_5Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::variadic_equal(Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for map_concat_map_4_5Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         map_concat_map_4_5_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for map_concat_map_4_5Func {
         map_concat_map_4_5_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         map_concat_map_4_5_simplify(args, info)
     }
+
 }

--- a/src/trino/map_entries_impl.rs
+++ b/src/trino/map_entries_impl.rs
@@ -50,13 +50,14 @@ fn map_entries_map_4_5_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct map_entries_map_4_5Func {
     signature: Signature,
 }
 
 impl map_entries_map_4_5Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for map_entries_map_4_5Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         map_entries_map_4_5_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for map_entries_map_4_5Func {
         map_entries_map_4_5_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         map_entries_map_4_5_simplify(args, info)
     }
+
 }

--- a/src/trino/map_filter_impl.rs
+++ b/src/trino/map_filter_impl.rs
@@ -54,13 +54,14 @@ fn map_filter_map_4_5_function_4_5_boolean_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct map_filter_map_4_5_function_4_5_booleanFunc {
     signature: Signature,
 }
 
 impl map_filter_map_4_5_function_4_5_booleanFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -79,6 +80,7 @@ impl ScalarUDFImpl for map_filter_map_4_5_function_4_5_booleanFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         map_filter_map_4_5_function_4_5_boolean_return_type(arg_types)
     }
@@ -87,7 +89,12 @@ impl ScalarUDFImpl for map_filter_map_4_5_function_4_5_booleanFunc {
         map_filter_map_4_5_function_4_5_boolean_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         map_filter_map_4_5_function_4_5_boolean_simplify(args, info)
     }
+
 }

--- a/src/trino/map_from_entries_impl.rs
+++ b/src/trino/map_from_entries_impl.rs
@@ -50,13 +50,14 @@ fn map_from_entries_array_row_c04_c15_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct map_from_entries_array_row_c04_c15Func {
     signature: Signature,
 }
 
 impl map_from_entries_array_row_c04_c15Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for map_from_entries_array_row_c04_c15Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         map_from_entries_array_row_c04_c15_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for map_from_entries_array_row_c04_c15Func {
         map_from_entries_array_row_c04_c15_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         map_from_entries_array_row_c04_c15_simplify(args, info)
     }
+
 }

--- a/src/trino/map_impl.rs
+++ b/src/trino/map_impl.rs
@@ -70,13 +70,14 @@ fn map_simplify(args: Vec<Expr>, _info: &dyn SimplifyInfo) -> Result<ExprSimplif
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct map_array_4_array_5Func {
     signature: Signature,
 }
 
 impl map_array_4_array_5Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -95,6 +96,7 @@ impl ScalarUDFImpl for map_array_4_array_5Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         map_array_4_array_5_return_type(arg_types)
     }
@@ -103,9 +105,14 @@ impl ScalarUDFImpl for map_array_4_array_5Func {
         map_array_4_array_5_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         map_array_4_array_5_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -114,7 +121,7 @@ pub(super) struct mapFunc {
 }
 
 impl mapFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(0, Volatility::Immutable),
         }
@@ -133,6 +140,7 @@ impl ScalarUDFImpl for mapFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         map_return_type(arg_types)
     }
@@ -141,7 +149,12 @@ impl ScalarUDFImpl for mapFunc {
         map_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         map_simplify(args, info)
     }
+
 }

--- a/src/trino/map_keys_impl.rs
+++ b/src/trino/map_keys_impl.rs
@@ -50,13 +50,14 @@ fn map_keys_map_4_5_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct map_keys_map_4_5Func {
     signature: Signature,
 }
 
 impl map_keys_map_4_5Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for map_keys_map_4_5Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         map_keys_map_4_5_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for map_keys_map_4_5Func {
         map_keys_map_4_5_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         map_keys_map_4_5_simplify(args, info)
     }
+
 }

--- a/src/trino/map_values_impl.rs
+++ b/src/trino/map_values_impl.rs
@@ -50,13 +50,14 @@ fn map_values_map_4_5_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct map_values_map_4_5Func {
     signature: Signature,
 }
 
 impl map_values_map_4_5Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for map_values_map_4_5Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         map_values_map_4_5_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for map_values_map_4_5Func {
         map_values_map_4_5_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         map_values_map_4_5_simplify(args, info)
     }
+
 }

--- a/src/trino/map_zip_with_impl.rs
+++ b/src/trino/map_zip_with_impl.rs
@@ -54,13 +54,14 @@ fn map_zip_with_map_4_8_map_4_7_function_4_8_7_6_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct map_zip_with_map_4_8_map_4_7_function_4_8_7_6Func {
     signature: Signature,
 }
 
 impl map_zip_with_map_4_8_map_4_7_function_4_8_7_6Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(3, Volatility::Immutable),
         }
@@ -79,6 +80,7 @@ impl ScalarUDFImpl for map_zip_with_map_4_8_map_4_7_function_4_8_7_6Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         map_zip_with_map_4_8_map_4_7_function_4_8_7_6_return_type(arg_types)
     }
@@ -87,7 +89,12 @@ impl ScalarUDFImpl for map_zip_with_map_4_8_map_4_7_function_4_8_7_6Func {
         map_zip_with_map_4_8_map_4_7_function_4_8_7_6_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         map_zip_with_map_4_8_map_4_7_function_4_8_7_6_simplify(args, info)
     }
+
 }

--- a/src/trino/md5_impl.rs
+++ b/src/trino/md5_impl.rs
@@ -47,13 +47,14 @@ fn md5_varbinary_simplify(args: Vec<Expr>, _info: &dyn SimplifyInfo) -> Result<E
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct md5_varbinaryFunc {
     signature: Signature,
 }
 
 impl md5_varbinaryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -72,6 +73,7 @@ impl ScalarUDFImpl for md5_varbinaryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         md5_varbinary_return_type(arg_types)
     }
@@ -80,7 +82,12 @@ impl ScalarUDFImpl for md5_varbinaryFunc {
         md5_varbinary_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         md5_varbinary_simplify(args, info)
     }
+
 }

--- a/src/trino/millisecond_impl.rs
+++ b/src/trino/millisecond_impl.rs
@@ -83,13 +83,14 @@ fn millisecond_timestamp_p_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct millisecond_intervaldaytosecondFunc {
     signature: Signature,
 }
 
 impl millisecond_intervaldaytosecondFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -108,6 +109,7 @@ impl ScalarUDFImpl for millisecond_intervaldaytosecondFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         millisecond_intervaldaytosecond_return_type(arg_types)
     }
@@ -116,9 +118,14 @@ impl ScalarUDFImpl for millisecond_intervaldaytosecondFunc {
         millisecond_intervaldaytosecond_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         millisecond_intervaldaytosecond_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -127,7 +134,7 @@ pub(super) struct millisecond_time_pFunc {
 }
 
 impl millisecond_time_pFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -146,6 +153,7 @@ impl ScalarUDFImpl for millisecond_time_pFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         millisecond_time_p_return_type(arg_types)
     }
@@ -154,9 +162,14 @@ impl ScalarUDFImpl for millisecond_time_pFunc {
         millisecond_time_p_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         millisecond_time_p_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -165,7 +178,7 @@ pub(super) struct millisecond_timestamp_pFunc {
 }
 
 impl millisecond_timestamp_pFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -184,6 +197,7 @@ impl ScalarUDFImpl for millisecond_timestamp_pFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         millisecond_timestamp_p_return_type(arg_types)
     }
@@ -192,7 +206,12 @@ impl ScalarUDFImpl for millisecond_timestamp_pFunc {
         millisecond_timestamp_p_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         millisecond_timestamp_p_simplify(args, info)
     }
+
 }

--- a/src/trino/minute_impl.rs
+++ b/src/trino/minute_impl.rs
@@ -80,13 +80,14 @@ fn minute_timestamp_p_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct minute_intervaldaytosecondFunc {
     signature: Signature,
 }
 
 impl minute_intervaldaytosecondFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -105,6 +106,7 @@ impl ScalarUDFImpl for minute_intervaldaytosecondFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         minute_intervaldaytosecond_return_type(arg_types)
     }
@@ -113,9 +115,14 @@ impl ScalarUDFImpl for minute_intervaldaytosecondFunc {
         minute_intervaldaytosecond_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         minute_intervaldaytosecond_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -124,7 +131,7 @@ pub(super) struct minute_time_pFunc {
 }
 
 impl minute_time_pFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -143,6 +150,7 @@ impl ScalarUDFImpl for minute_time_pFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         minute_time_p_return_type(arg_types)
     }
@@ -151,9 +159,14 @@ impl ScalarUDFImpl for minute_time_pFunc {
         minute_time_p_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         minute_time_p_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -162,7 +175,7 @@ pub(super) struct minute_timestamp_pFunc {
 }
 
 impl minute_timestamp_pFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -181,6 +194,7 @@ impl ScalarUDFImpl for minute_timestamp_pFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         minute_timestamp_p_return_type(arg_types)
     }
@@ -189,7 +203,12 @@ impl ScalarUDFImpl for minute_timestamp_pFunc {
         minute_timestamp_p_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         minute_timestamp_p_simplify(args, info)
     }
+
 }

--- a/src/trino/mod.rs
+++ b/src/trino/mod.rs
@@ -33,13 +33,13 @@ mod array_union_impl;
 mod arrays_overlap_impl;
 mod asin_impl;
 mod at_timezone_impl;
-mod atan2_impl;
 mod atan_impl;
+mod atan2_impl;
 mod bar_impl;
 mod beta_cdf_impl;
+mod bing_tile_impl;
 mod bing_tile_at_impl;
 mod bing_tile_coordinates_impl;
-mod bing_tile_impl;
 mod bing_tile_polygon_impl;
 mod bing_tile_quadkey_impl;
 mod bing_tile_zoom_level_impl;
@@ -49,8 +49,8 @@ mod bitwise_and_impl;
 mod bitwise_left_shift_impl;
 mod bitwise_not_impl;
 mod bitwise_or_impl;
-mod bitwise_right_shift_arithmetic_impl;
 mod bitwise_right_shift_impl;
+mod bitwise_right_shift_arithmetic_impl;
 mod bitwise_xor_impl;
 mod cardinality_impl;
 mod cbrt_impl;
@@ -79,10 +79,10 @@ mod current_time_impl;
 mod current_timestamp_impl;
 mod current_timezone_impl;
 mod current_user_impl;
+mod date_impl;
 mod date_add_impl;
 mod date_diff_impl;
 mod date_format_impl;
-mod date_impl;
 mod date_parse_impl;
 mod date_trunc_impl;
 mod day_impl;
@@ -100,13 +100,13 @@ mod features_impl;
 mod filter_impl;
 mod flatten_impl;
 mod floor_impl;
-mod format_datetime_impl;
 mod format_impl;
+mod format_datetime_impl;
 mod format_number_impl;
+mod from_base_impl;
 mod from_base32_impl;
 mod from_base64_impl;
 mod from_base64url_impl;
-mod from_base_impl;
 mod from_big_endian_32_impl;
 mod from_big_endian_64_impl;
 mod from_encoded_polyline_impl;
@@ -164,18 +164,18 @@ mod line_locate_point_impl;
 mod ln_impl;
 mod localtime_impl;
 mod localtimestamp_impl;
+mod log_impl;
 mod log10_impl;
 mod log2_impl;
-mod log_impl;
 mod lower_impl;
 mod lpad_impl;
 mod ltrim_impl;
 mod luhn_check_impl;
+mod map_impl;
 mod map_concat_impl;
 mod map_entries_impl;
 mod map_filter_impl;
 mod map_from_entries_impl;
-mod map_impl;
 mod map_keys_impl;
 mod map_values_impl;
 mod map_zip_with_impl;
@@ -209,8 +209,8 @@ mod rand_impl;
 mod random_impl;
 mod reduce_impl;
 mod regexp_count_impl;
-mod regexp_extract_all_impl;
 mod regexp_extract_impl;
+mod regexp_extract_all_impl;
 mod regexp_like_impl;
 mod regexp_position_impl;
 mod regexp_replace_impl;
@@ -310,10 +310,10 @@ mod tanh_impl;
 mod timestamp_objectid_impl;
 mod timezone_hour_impl;
 mod timezone_minute_impl;
+mod to_base_impl;
 mod to_base32_impl;
 mod to_base64_impl;
 mod to_base64url_impl;
-mod to_base_impl;
 mod to_big_endian_32_impl;
 mod to_big_endian_64_impl;
 mod to_char_impl;
@@ -334,8 +334,8 @@ mod transform_impl;
 mod transform_keys_impl;
 mod transform_values_impl;
 mod translate_impl;
-mod trim_array_impl;
 mod trim_impl;
+mod trim_array_impl;
 mod truncate_impl;
 mod try_impl;
 mod typeof_impl;
@@ -366,1307 +366,419 @@ mod yow_impl;
 mod zip_impl;
 mod zip_with_impl;
 
+
 // create  UDFs
 make_udf_function!(abs_impl::abs_tinyintFunc, ABS_TINYINT, abs_tinyint);
 make_udf_function!(abs_impl::abs_smallintFunc, ABS_SMALLINT, abs_smallint);
 make_udf_function!(abs_impl::abs_bigintFunc, ABS_BIGINT, abs_bigint);
 make_udf_function!(abs_impl::abs_doubleFunc, ABS_DOUBLE, abs_double);
-make_udf_function!(
-    abs_impl::abs_decimal_p_sFunc,
-    ABS_DECIMAL_P_S,
-    abs_decimal_p_s
-);
+make_udf_function!(abs_impl::abs_decimal_p_sFunc, ABS_DECIMAL_P_S, abs_decimal_p_s);
 make_udf_function!(abs_impl::abs_realFunc, ABS_REAL, abs_real);
 
 make_udf_function!(acos_impl::acos_doubleFunc, ACOS_DOUBLE, acos_double);
 
-make_udf_function!(
-    all_match_impl::all_match_array_1_function_1_booleanFunc,
-    ALL_MATCH_ARRAY_1_FUNCTION_1_BOOLEAN,
-    all_match_array_1_function_1_boolean
-);
+make_udf_function!(all_match_impl::all_match_array_1_function_1_booleanFunc, ALL_MATCH_ARRAY_1_FUNCTION_1_BOOLEAN, all_match_array_1_function_1_boolean);
 
-make_udf_function!(
-    any_match_impl::any_match_array_1_function_1_booleanFunc,
-    ANY_MATCH_ARRAY_1_FUNCTION_1_BOOLEAN,
-    any_match_array_1_function_1_boolean
-);
+make_udf_function!(any_match_impl::any_match_array_1_function_1_booleanFunc, ANY_MATCH_ARRAY_1_FUNCTION_1_BOOLEAN, any_match_array_1_function_1_boolean);
 
-make_udf_function!(
-    array_distinct_impl::array_distinct_array_3Func,
-    ARRAY_DISTINCT_ARRAY_3,
-    array_distinct_array_3
-);
+make_udf_function!(array_distinct_impl::array_distinct_array_3Func, ARRAY_DISTINCT_ARRAY_3, array_distinct_array_3);
 
-make_udf_function!(
-    array_except_impl::array_except_array_3_array_3Func,
-    ARRAY_EXCEPT_ARRAY_3_ARRAY_3,
-    array_except_array_3_array_3
-);
+make_udf_function!(array_except_impl::array_except_array_3_array_3Func, ARRAY_EXCEPT_ARRAY_3_ARRAY_3, array_except_array_3_array_3);
 
-make_udf_function!(
-    array_intersect_impl::array_intersect_array_3_array_3Func,
-    ARRAY_INTERSECT_ARRAY_3_ARRAY_3,
-    array_intersect_array_3_array_3
-);
+make_udf_function!(array_intersect_impl::array_intersect_array_3_array_3Func, ARRAY_INTERSECT_ARRAY_3_ARRAY_3, array_intersect_array_3_array_3);
 
-make_udf_function!(
-    array_join_impl::array_join_array_1_varcharFunc,
-    ARRAY_JOIN_ARRAY_1_VARCHAR,
-    array_join_array_1_varchar
-);
-make_udf_function!(
-    array_join_impl::array_join_array_1_varchar_varcharFunc,
-    ARRAY_JOIN_ARRAY_1_VARCHAR_VARCHAR,
-    array_join_array_1_varchar_varchar
-);
+make_udf_function!(array_join_impl::array_join_array_1_varcharFunc, ARRAY_JOIN_ARRAY_1_VARCHAR, array_join_array_1_varchar);
+make_udf_function!(array_join_impl::array_join_array_1_varchar_varcharFunc, ARRAY_JOIN_ARRAY_1_VARCHAR_VARCHAR, array_join_array_1_varchar_varchar);
 
-make_udf_function!(
-    array_max_impl::array_max_array_1Func,
-    ARRAY_MAX_ARRAY_1,
-    array_max_array_1
-);
+make_udf_function!(array_max_impl::array_max_array_1Func, ARRAY_MAX_ARRAY_1, array_max_array_1);
 
-make_udf_function!(
-    array_min_impl::array_min_array_1Func,
-    ARRAY_MIN_ARRAY_1,
-    array_min_array_1
-);
+make_udf_function!(array_min_impl::array_min_array_1Func, ARRAY_MIN_ARRAY_1, array_min_array_1);
 
-make_udf_function!(
-    array_position_impl::array_position_array_1_1Func,
-    ARRAY_POSITION_ARRAY_1_1,
-    array_position_array_1_1
-);
+make_udf_function!(array_position_impl::array_position_array_1_1Func, ARRAY_POSITION_ARRAY_1_1, array_position_array_1_1);
 
-make_udf_function!(
-    array_remove_impl::array_remove_array_3_3Func,
-    ARRAY_REMOVE_ARRAY_3_3,
-    array_remove_array_3_3
-);
+make_udf_function!(array_remove_impl::array_remove_array_3_3Func, ARRAY_REMOVE_ARRAY_3_3, array_remove_array_3_3);
 
-make_udf_function!(
-    array_sort_impl::array_sort_array_3Func,
-    ARRAY_SORT_ARRAY_3,
-    array_sort_array_3
-);
-make_udf_function!(
-    array_sort_impl::array_sort_array_1_function_1_1_bigintFunc,
-    ARRAY_SORT_ARRAY_1_FUNCTION_1_1_BIGINT,
-    array_sort_array_1_function_1_1_bigint
-);
+make_udf_function!(array_sort_impl::array_sort_array_3Func, ARRAY_SORT_ARRAY_3, array_sort_array_3);
+make_udf_function!(array_sort_impl::array_sort_array_1_function_1_1_bigintFunc, ARRAY_SORT_ARRAY_1_FUNCTION_1_1_BIGINT, array_sort_array_1_function_1_1_bigint);
 
-make_udf_function!(
-    array_union_impl::array_union_array_3_array_3Func,
-    ARRAY_UNION_ARRAY_3_ARRAY_3,
-    array_union_array_3_array_3
-);
+make_udf_function!(array_union_impl::array_union_array_3_array_3Func, ARRAY_UNION_ARRAY_3_ARRAY_3, array_union_array_3_array_3);
 
-make_udf_function!(
-    arrays_overlap_impl::arrays_overlap_array_3_array_3Func,
-    ARRAYS_OVERLAP_ARRAY_3_ARRAY_3,
-    arrays_overlap_array_3_array_3
-);
+make_udf_function!(arrays_overlap_impl::arrays_overlap_array_3_array_3Func, ARRAYS_OVERLAP_ARRAY_3_ARRAY_3, arrays_overlap_array_3_array_3);
 
 make_udf_function!(asin_impl::asin_doubleFunc, ASIN_DOUBLE, asin_double);
 
-make_udf_function!(
-    at_timezone_impl::at_timezone_timestamp_p_varcharFunc,
-    AT_TIMEZONE_TIMESTAMP_P_VARCHAR,
-    at_timezone_timestamp_p_varchar
-);
+make_udf_function!(at_timezone_impl::at_timezone_timestamp_p_varcharFunc, AT_TIMEZONE_TIMESTAMP_P_VARCHAR, at_timezone_timestamp_p_varchar);
 
 make_udf_function!(atan_impl::atan_doubleFunc, ATAN_DOUBLE, atan_double);
 
-make_udf_function!(
-    atan2_impl::atan2_double_doubleFunc,
-    ATAN2_DOUBLE_DOUBLE,
-    atan2_double_double
-);
+make_udf_function!(atan2_impl::atan2_double_doubleFunc, ATAN2_DOUBLE_DOUBLE, atan2_double_double);
 
-make_udf_function!(
-    bar_impl::bar_double_bigintFunc,
-    BAR_DOUBLE_BIGINT,
-    bar_double_bigint
-);
-make_udf_function!(
-    bar_impl::bar_double_bigint_color_colorFunc,
-    BAR_DOUBLE_BIGINT_COLOR_COLOR,
-    bar_double_bigint_color_color
-);
+make_udf_function!(bar_impl::bar_double_bigintFunc, BAR_DOUBLE_BIGINT, bar_double_bigint);
+make_udf_function!(bar_impl::bar_double_bigint_color_colorFunc, BAR_DOUBLE_BIGINT_COLOR_COLOR, bar_double_bigint_color_color);
 
-make_udf_function!(
-    beta_cdf_impl::beta_cdf_double_double_doubleFunc,
-    BETA_CDF_DOUBLE_DOUBLE_DOUBLE,
-    beta_cdf_double_double_double
-);
+make_udf_function!(beta_cdf_impl::beta_cdf_double_double_doubleFunc, BETA_CDF_DOUBLE_DOUBLE_DOUBLE, beta_cdf_double_double_double);
 
-make_udf_function!(
-    bing_tile_impl::bing_tile_bigint_bigint_bigintFunc,
-    BING_TILE_BIGINT_BIGINT_BIGINT,
-    bing_tile_bigint_bigint_bigint
-);
-make_udf_function!(
-    bing_tile_impl::bing_tile_varcharFunc,
-    BING_TILE_VARCHAR,
-    bing_tile_varchar
-);
+make_udf_function!(bing_tile_impl::bing_tile_bigint_bigint_bigintFunc, BING_TILE_BIGINT_BIGINT_BIGINT, bing_tile_bigint_bigint_bigint);
+make_udf_function!(bing_tile_impl::bing_tile_varcharFunc, BING_TILE_VARCHAR, bing_tile_varchar);
 
-make_udf_function!(
-    bing_tile_at_impl::bing_tile_at_double_double_bigintFunc,
-    BING_TILE_AT_DOUBLE_DOUBLE_BIGINT,
-    bing_tile_at_double_double_bigint
-);
+make_udf_function!(bing_tile_at_impl::bing_tile_at_double_double_bigintFunc, BING_TILE_AT_DOUBLE_DOUBLE_BIGINT, bing_tile_at_double_double_bigint);
 
-make_udf_function!(
-    bing_tile_coordinates_impl::bing_tile_coordinates_bingtileFunc,
-    BING_TILE_COORDINATES_BINGTILE,
-    bing_tile_coordinates_bingtile
-);
+make_udf_function!(bing_tile_coordinates_impl::bing_tile_coordinates_bingtileFunc, BING_TILE_COORDINATES_BINGTILE, bing_tile_coordinates_bingtile);
 
-make_udf_function!(
-    bing_tile_polygon_impl::bing_tile_polygon_bingtileFunc,
-    BING_TILE_POLYGON_BINGTILE,
-    bing_tile_polygon_bingtile
-);
+make_udf_function!(bing_tile_polygon_impl::bing_tile_polygon_bingtileFunc, BING_TILE_POLYGON_BINGTILE, bing_tile_polygon_bingtile);
 
-make_udf_function!(
-    bing_tile_quadkey_impl::bing_tile_quadkey_bingtileFunc,
-    BING_TILE_QUADKEY_BINGTILE,
-    bing_tile_quadkey_bingtile
-);
+make_udf_function!(bing_tile_quadkey_impl::bing_tile_quadkey_bingtileFunc, BING_TILE_QUADKEY_BINGTILE, bing_tile_quadkey_bingtile);
 
-make_udf_function!(
-    bing_tile_zoom_level_impl::bing_tile_zoom_level_bingtileFunc,
-    BING_TILE_ZOOM_LEVEL_BINGTILE,
-    bing_tile_zoom_level_bingtile
-);
+make_udf_function!(bing_tile_zoom_level_impl::bing_tile_zoom_level_bingtileFunc, BING_TILE_ZOOM_LEVEL_BINGTILE, bing_tile_zoom_level_bingtile);
 
-make_udf_function!(
-    bing_tiles_around_impl::bing_tiles_around_double_double_bigintFunc,
-    BING_TILES_AROUND_DOUBLE_DOUBLE_BIGINT,
-    bing_tiles_around_double_double_bigint
-);
-make_udf_function!(
-    bing_tiles_around_impl::bing_tiles_around_double_double_bigint_doubleFunc,
-    BING_TILES_AROUND_DOUBLE_DOUBLE_BIGINT_DOUBLE,
-    bing_tiles_around_double_double_bigint_double
-);
+make_udf_function!(bing_tiles_around_impl::bing_tiles_around_double_double_bigintFunc, BING_TILES_AROUND_DOUBLE_DOUBLE_BIGINT, bing_tiles_around_double_double_bigint);
+make_udf_function!(bing_tiles_around_impl::bing_tiles_around_double_double_bigint_doubleFunc, BING_TILES_AROUND_DOUBLE_DOUBLE_BIGINT_DOUBLE, bing_tiles_around_double_double_bigint_double);
 
-make_udf_function!(
-    bit_count_impl::bit_count_bigint_bigintFunc,
-    BIT_COUNT_BIGINT_BIGINT,
-    bit_count_bigint_bigint
-);
+make_udf_function!(bit_count_impl::bit_count_bigint_bigintFunc, BIT_COUNT_BIGINT_BIGINT, bit_count_bigint_bigint);
 
-make_udf_function!(
-    bitwise_and_impl::bitwise_and_bigint_bigintFunc,
-    BITWISE_AND_BIGINT_BIGINT,
-    bitwise_and_bigint_bigint
-);
+make_udf_function!(bitwise_and_impl::bitwise_and_bigint_bigintFunc, BITWISE_AND_BIGINT_BIGINT, bitwise_and_bigint_bigint);
 
-make_udf_function!(
-    bitwise_left_shift_impl::bitwise_left_shift_bigint_bigintFunc,
-    BITWISE_LEFT_SHIFT_BIGINT_BIGINT,
-    bitwise_left_shift_bigint_bigint
-);
-make_udf_function!(
-    bitwise_left_shift_impl::bitwise_left_shift_integer_bigintFunc,
-    BITWISE_LEFT_SHIFT_INTEGER_BIGINT,
-    bitwise_left_shift_integer_bigint
-);
-make_udf_function!(
-    bitwise_left_shift_impl::bitwise_left_shift_smallint_bigintFunc,
-    BITWISE_LEFT_SHIFT_SMALLINT_BIGINT,
-    bitwise_left_shift_smallint_bigint
-);
-make_udf_function!(
-    bitwise_left_shift_impl::bitwise_left_shift_tinyint_bigintFunc,
-    BITWISE_LEFT_SHIFT_TINYINT_BIGINT,
-    bitwise_left_shift_tinyint_bigint
-);
+make_udf_function!(bitwise_left_shift_impl::bitwise_left_shift_bigint_bigintFunc, BITWISE_LEFT_SHIFT_BIGINT_BIGINT, bitwise_left_shift_bigint_bigint);
+make_udf_function!(bitwise_left_shift_impl::bitwise_left_shift_integer_bigintFunc, BITWISE_LEFT_SHIFT_INTEGER_BIGINT, bitwise_left_shift_integer_bigint);
+make_udf_function!(bitwise_left_shift_impl::bitwise_left_shift_smallint_bigintFunc, BITWISE_LEFT_SHIFT_SMALLINT_BIGINT, bitwise_left_shift_smallint_bigint);
+make_udf_function!(bitwise_left_shift_impl::bitwise_left_shift_tinyint_bigintFunc, BITWISE_LEFT_SHIFT_TINYINT_BIGINT, bitwise_left_shift_tinyint_bigint);
 
-make_udf_function!(
-    bitwise_not_impl::bitwise_not_bigintFunc,
-    BITWISE_NOT_BIGINT,
-    bitwise_not_bigint
-);
+make_udf_function!(bitwise_not_impl::bitwise_not_bigintFunc, BITWISE_NOT_BIGINT, bitwise_not_bigint);
 
-make_udf_function!(
-    bitwise_or_impl::bitwise_or_bigint_bigintFunc,
-    BITWISE_OR_BIGINT_BIGINT,
-    bitwise_or_bigint_bigint
-);
+make_udf_function!(bitwise_or_impl::bitwise_or_bigint_bigintFunc, BITWISE_OR_BIGINT_BIGINT, bitwise_or_bigint_bigint);
 
-make_udf_function!(
-    bitwise_right_shift_impl::bitwise_right_shift_bigint_bigintFunc,
-    BITWISE_RIGHT_SHIFT_BIGINT_BIGINT,
-    bitwise_right_shift_bigint_bigint
-);
-make_udf_function!(
-    bitwise_right_shift_impl::bitwise_right_shift_integer_bigintFunc,
-    BITWISE_RIGHT_SHIFT_INTEGER_BIGINT,
-    bitwise_right_shift_integer_bigint
-);
-make_udf_function!(
-    bitwise_right_shift_impl::bitwise_right_shift_smallint_bigintFunc,
-    BITWISE_RIGHT_SHIFT_SMALLINT_BIGINT,
-    bitwise_right_shift_smallint_bigint
-);
-make_udf_function!(
-    bitwise_right_shift_impl::bitwise_right_shift_tinyint_bigintFunc,
-    BITWISE_RIGHT_SHIFT_TINYINT_BIGINT,
-    bitwise_right_shift_tinyint_bigint
-);
+make_udf_function!(bitwise_right_shift_impl::bitwise_right_shift_bigint_bigintFunc, BITWISE_RIGHT_SHIFT_BIGINT_BIGINT, bitwise_right_shift_bigint_bigint);
+make_udf_function!(bitwise_right_shift_impl::bitwise_right_shift_integer_bigintFunc, BITWISE_RIGHT_SHIFT_INTEGER_BIGINT, bitwise_right_shift_integer_bigint);
+make_udf_function!(bitwise_right_shift_impl::bitwise_right_shift_smallint_bigintFunc, BITWISE_RIGHT_SHIFT_SMALLINT_BIGINT, bitwise_right_shift_smallint_bigint);
+make_udf_function!(bitwise_right_shift_impl::bitwise_right_shift_tinyint_bigintFunc, BITWISE_RIGHT_SHIFT_TINYINT_BIGINT, bitwise_right_shift_tinyint_bigint);
 
-make_udf_function!(
-    bitwise_right_shift_arithmetic_impl::bitwise_right_shift_arithmetic_bigint_bigintFunc,
-    BITWISE_RIGHT_SHIFT_ARITHMETIC_BIGINT_BIGINT,
-    bitwise_right_shift_arithmetic_bigint_bigint
-);
-make_udf_function!(
-    bitwise_right_shift_arithmetic_impl::bitwise_right_shift_arithmetic_integer_bigintFunc,
-    BITWISE_RIGHT_SHIFT_ARITHMETIC_INTEGER_BIGINT,
-    bitwise_right_shift_arithmetic_integer_bigint
-);
-make_udf_function!(
-    bitwise_right_shift_arithmetic_impl::bitwise_right_shift_arithmetic_smallint_bigintFunc,
-    BITWISE_RIGHT_SHIFT_ARITHMETIC_SMALLINT_BIGINT,
-    bitwise_right_shift_arithmetic_smallint_bigint
-);
-make_udf_function!(
-    bitwise_right_shift_arithmetic_impl::bitwise_right_shift_arithmetic_tinyint_bigintFunc,
-    BITWISE_RIGHT_SHIFT_ARITHMETIC_TINYINT_BIGINT,
-    bitwise_right_shift_arithmetic_tinyint_bigint
-);
+make_udf_function!(bitwise_right_shift_arithmetic_impl::bitwise_right_shift_arithmetic_bigint_bigintFunc, BITWISE_RIGHT_SHIFT_ARITHMETIC_BIGINT_BIGINT, bitwise_right_shift_arithmetic_bigint_bigint);
+make_udf_function!(bitwise_right_shift_arithmetic_impl::bitwise_right_shift_arithmetic_integer_bigintFunc, BITWISE_RIGHT_SHIFT_ARITHMETIC_INTEGER_BIGINT, bitwise_right_shift_arithmetic_integer_bigint);
+make_udf_function!(bitwise_right_shift_arithmetic_impl::bitwise_right_shift_arithmetic_smallint_bigintFunc, BITWISE_RIGHT_SHIFT_ARITHMETIC_SMALLINT_BIGINT, bitwise_right_shift_arithmetic_smallint_bigint);
+make_udf_function!(bitwise_right_shift_arithmetic_impl::bitwise_right_shift_arithmetic_tinyint_bigintFunc, BITWISE_RIGHT_SHIFT_ARITHMETIC_TINYINT_BIGINT, bitwise_right_shift_arithmetic_tinyint_bigint);
 
-make_udf_function!(
-    bitwise_xor_impl::bitwise_xor_bigint_bigintFunc,
-    BITWISE_XOR_BIGINT_BIGINT,
-    bitwise_xor_bigint_bigint
-);
+make_udf_function!(bitwise_xor_impl::bitwise_xor_bigint_bigintFunc, BITWISE_XOR_BIGINT_BIGINT, bitwise_xor_bigint_bigint);
 
-make_udf_function!(
-    cardinality_impl::cardinality_array_3Func,
-    CARDINALITY_ARRAY_3,
-    cardinality_array_3
-);
-make_udf_function!(
-    cardinality_impl::cardinality_hyperloglogFunc,
-    CARDINALITY_HYPERLOGLOG,
-    cardinality_hyperloglog
-);
-make_udf_function!(
-    cardinality_impl::cardinality_map_4_5Func,
-    CARDINALITY_MAP_4_5,
-    cardinality_map_4_5
-);
-make_udf_function!(
-    cardinality_impl::cardinality_setdigestFunc,
-    CARDINALITY_SETDIGEST,
-    cardinality_setdigest
-);
+make_udf_function!(cardinality_impl::cardinality_array_3Func, CARDINALITY_ARRAY_3, cardinality_array_3);
+make_udf_function!(cardinality_impl::cardinality_hyperloglogFunc, CARDINALITY_HYPERLOGLOG, cardinality_hyperloglog);
+make_udf_function!(cardinality_impl::cardinality_map_4_5Func, CARDINALITY_MAP_4_5, cardinality_map_4_5);
+make_udf_function!(cardinality_impl::cardinality_setdigestFunc, CARDINALITY_SETDIGEST, cardinality_setdigest);
 
 make_udf_function!(cbrt_impl::cbrt_doubleFunc, CBRT_DOUBLE, cbrt_double);
 
 make_udf_function!(ceil_impl::ceil_bigintFunc, CEIL_BIGINT, ceil_bigint);
-make_udf_function!(
-    ceil_impl::ceil_decimal_p_sFunc,
-    CEIL_DECIMAL_P_S,
-    ceil_decimal_p_s
-);
+make_udf_function!(ceil_impl::ceil_decimal_p_sFunc, CEIL_DECIMAL_P_S, ceil_decimal_p_s);
 make_udf_function!(ceil_impl::ceil_doubleFunc, CEIL_DOUBLE, ceil_double);
 make_udf_function!(ceil_impl::ceil_integerFunc, CEIL_INTEGER, ceil_integer);
 make_udf_function!(ceil_impl::ceil_realFunc, CEIL_REAL, ceil_real);
 make_udf_function!(ceil_impl::ceil_smallintFunc, CEIL_SMALLINT, ceil_smallint);
 make_udf_function!(ceil_impl::ceil_tinyintFunc, CEIL_TINYINT, ceil_tinyint);
 
-make_udf_function!(
-    ceiling_impl::ceiling_bigintFunc,
-    CEILING_BIGINT,
-    ceiling_bigint
-);
-make_udf_function!(
-    ceiling_impl::ceiling_decimal_p_sFunc,
-    CEILING_DECIMAL_P_S,
-    ceiling_decimal_p_s
-);
-make_udf_function!(
-    ceiling_impl::ceiling_doubleFunc,
-    CEILING_DOUBLE,
-    ceiling_double
-);
-make_udf_function!(
-    ceiling_impl::ceiling_integerFunc,
-    CEILING_INTEGER,
-    ceiling_integer
-);
+make_udf_function!(ceiling_impl::ceiling_bigintFunc, CEILING_BIGINT, ceiling_bigint);
+make_udf_function!(ceiling_impl::ceiling_decimal_p_sFunc, CEILING_DECIMAL_P_S, ceiling_decimal_p_s);
+make_udf_function!(ceiling_impl::ceiling_doubleFunc, CEILING_DOUBLE, ceiling_double);
+make_udf_function!(ceiling_impl::ceiling_integerFunc, CEILING_INTEGER, ceiling_integer);
 make_udf_function!(ceiling_impl::ceiling_realFunc, CEILING_REAL, ceiling_real);
-make_udf_function!(
-    ceiling_impl::ceiling_smallintFunc,
-    CEILING_SMALLINT,
-    ceiling_smallint
-);
-make_udf_function!(
-    ceiling_impl::ceiling_tinyintFunc,
-    CEILING_TINYINT,
-    ceiling_tinyint
-);
+make_udf_function!(ceiling_impl::ceiling_smallintFunc, CEILING_SMALLINT, ceiling_smallint);
+make_udf_function!(ceiling_impl::ceiling_tinyintFunc, CEILING_TINYINT, ceiling_tinyint);
 
-make_udf_function!(
-    char2hexint_impl::char2hexint_varcharFunc,
-    CHAR2HEXINT_VARCHAR,
-    char2hexint_varchar
-);
+make_udf_function!(char2hexint_impl::char2hexint_varcharFunc, CHAR2HEXINT_VARCHAR, char2hexint_varchar);
 
 make_udf_function!(chr_impl::chr_bigintFunc, CHR_BIGINT, chr_bigint);
 
-make_udf_function!(
-    classify_impl::classify_map_bigint_double_classifierFunc,
-    CLASSIFY_MAP_BIGINT_DOUBLE_CLASSIFIER,
-    classify_map_bigint_double_classifier
-);
+make_udf_function!(classify_impl::classify_map_bigint_double_classifierFunc, CLASSIFY_MAP_BIGINT_DOUBLE_CLASSIFIER, classify_map_bigint_double_classifier);
 
 make_udf_function!(coalesce_impl::coalesce_1Func, COALESCE_1, coalesce_1);
 
-make_udf_function!(
-    codepoint_impl::codepoint_varcharFunc,
-    CODEPOINT_VARCHAR,
-    codepoint_varchar
-);
+make_udf_function!(codepoint_impl::codepoint_varcharFunc, CODEPOINT_VARCHAR, codepoint_varchar);
 
-make_udf_function!(
-    color_impl::color_double_color_colorFunc,
-    COLOR_DOUBLE_COLOR_COLOR,
-    color_double_color_color
-);
-make_udf_function!(
-    color_impl::color_double_double_double_color_colorFunc,
-    COLOR_DOUBLE_DOUBLE_DOUBLE_COLOR_COLOR,
-    color_double_double_double_color_color
-);
+make_udf_function!(color_impl::color_double_color_colorFunc, COLOR_DOUBLE_COLOR_COLOR, color_double_color_color);
+make_udf_function!(color_impl::color_double_double_double_color_colorFunc, COLOR_DOUBLE_DOUBLE_DOUBLE_COLOR_COLOR, color_double_double_double_color_color);
 make_udf_function!(color_impl::color_varcharFunc, COLOR_VARCHAR, color_varchar);
 
-make_udf_function!(
-    combinations_impl::combinations_array_1_bigintFunc,
-    COMBINATIONS_ARRAY_1_BIGINT,
-    combinations_array_1_bigint
-);
+make_udf_function!(combinations_impl::combinations_array_1_bigintFunc, COMBINATIONS_ARRAY_1_BIGINT, combinations_array_1_bigint);
 
-make_udf_function!(
-    concat_impl::concat_3_array_3Func,
-    CONCAT_3_ARRAY_3,
-    concat_3_array_3
-);
-make_udf_function!(
-    concat_impl::concat_array_3Func,
-    CONCAT_ARRAY_3,
-    concat_array_3
-);
-make_udf_function!(
-    concat_impl::concat_array_3_3Func,
-    CONCAT_ARRAY_3_3,
-    concat_array_3_3
-);
-make_udf_function!(
-    concat_impl::concat_varchar_varcharFunc,
-    CONCAT_VARCHAR_VARCHAR,
-    concat_varchar_varchar
-);
-make_udf_function!(
-    concat_impl::concat_varcharFunc,
-    CONCAT_VARCHAR,
-    concat_varchar
-);
-make_udf_function!(
-    concat_impl::concat_varbinaryFunc,
-    CONCAT_VARBINARY,
-    concat_varbinary
-);
+make_udf_function!(concat_impl::concat_3_array_3Func, CONCAT_3_ARRAY_3, concat_3_array_3);
+make_udf_function!(concat_impl::concat_array_3Func, CONCAT_ARRAY_3, concat_array_3);
+make_udf_function!(concat_impl::concat_array_3_3Func, CONCAT_ARRAY_3_3, concat_array_3_3);
+make_udf_function!(concat_impl::concat_varchar_varcharFunc, CONCAT_VARCHAR_VARCHAR, concat_varchar_varchar);
+make_udf_function!(concat_impl::concat_varcharFunc, CONCAT_VARCHAR, concat_varchar);
+make_udf_function!(concat_impl::concat_varbinaryFunc, CONCAT_VARBINARY, concat_varbinary);
 
-make_udf_function!(
-    concat_ws_impl::concat_ws_varchar_array_varcharFunc,
-    CONCAT_WS_VARCHAR_ARRAY_VARCHAR,
-    concat_ws_varchar_array_varchar
-);
-make_udf_function!(
-    concat_ws_impl::concat_ws_varcharFunc,
-    CONCAT_WS_VARCHAR,
-    concat_ws_varchar
-);
+make_udf_function!(concat_ws_impl::concat_ws_varchar_array_varcharFunc, CONCAT_WS_VARCHAR_ARRAY_VARCHAR, concat_ws_varchar_array_varchar);
+make_udf_function!(concat_ws_impl::concat_ws_varcharFunc, CONCAT_WS_VARCHAR, concat_ws_varchar);
 
-make_udf_function!(
-    contains_impl::contains_array_1_1Func,
-    CONTAINS_ARRAY_1_1,
-    contains_array_1_1
-);
-make_udf_function!(
-    contains_impl::contains_varchar_ipaddressFunc,
-    CONTAINS_VARCHAR_IPADDRESS,
-    contains_varchar_ipaddress
-);
+make_udf_function!(contains_impl::contains_array_1_1Func, CONTAINS_ARRAY_1_1, contains_array_1_1);
+make_udf_function!(contains_impl::contains_varchar_ipaddressFunc, CONTAINS_VARCHAR_IPADDRESS, contains_varchar_ipaddress);
 
-make_udf_function!(
-    contains_sequence_impl::contains_sequence_array_1_array_1Func,
-    CONTAINS_SEQUENCE_ARRAY_1_ARRAY_1,
-    contains_sequence_array_1_array_1
-);
+make_udf_function!(contains_sequence_impl::contains_sequence_array_1_array_1Func, CONTAINS_SEQUENCE_ARRAY_1_ARRAY_1, contains_sequence_array_1_array_1);
 
 make_udf_function!(cos_impl::cos_doubleFunc, COS_DOUBLE, cos_double);
 
 make_udf_function!(cosh_impl::cosh_doubleFunc, COSH_DOUBLE, cosh_double);
 
-make_udf_function!(
-    cosine_similarity_impl::cosine_similarity_map_varchar_double_map_varchar_doubleFunc,
-    COSINE_SIMILARITY_MAP_VARCHAR_DOUBLE_MAP_VARCHAR_DOUBLE,
-    cosine_similarity_map_varchar_double_map_varchar_double
-);
+make_udf_function!(cosine_similarity_impl::cosine_similarity_map_varchar_double_map_varchar_doubleFunc, COSINE_SIMILARITY_MAP_VARCHAR_DOUBLE_MAP_VARCHAR_DOUBLE, cosine_similarity_map_varchar_double_map_varchar_double);
 
-make_udf_function!(
-    crc32_impl::crc32_varbinaryFunc,
-    CRC32_VARBINARY,
-    crc32_varbinary
-);
+make_udf_function!(crc32_impl::crc32_varbinaryFunc, CRC32_VARBINARY, crc32_varbinary);
 
-make_udf_function!(
-    current_catalog_impl::current_catalogFunc,
-    CURRENT_CATALOG,
-    current_catalog
-);
+make_udf_function!(current_catalog_impl::current_catalogFunc, CURRENT_CATALOG, current_catalog);
 
-make_udf_function!(
-    current_date_impl::current_dateFunc,
-    CURRENT_DATE,
-    current_date
-);
+make_udf_function!(current_date_impl::current_dateFunc, CURRENT_DATE, current_date);
 
-make_udf_function!(
-    current_groups_impl::current_groupsFunc,
-    CURRENT_GROUPS,
-    current_groups
-);
+make_udf_function!(current_groups_impl::current_groupsFunc, CURRENT_GROUPS, current_groups);
 
-make_udf_function!(
-    current_schema_impl::current_schemaFunc,
-    CURRENT_SCHEMA,
-    current_schema
-);
+make_udf_function!(current_schema_impl::current_schemaFunc, CURRENT_SCHEMA, current_schema);
 
-make_udf_function!(
-    current_time_impl::current_timeFunc,
-    CURRENT_TIME,
-    current_time
-);
+make_udf_function!(current_time_impl::current_timeFunc, CURRENT_TIME, current_time);
 
-make_udf_function!(
-    current_timestamp_impl::current_timestampFunc,
-    CURRENT_TIMESTAMP,
-    current_timestamp
-);
-make_udf_function!(
-    current_timestamp_impl::current_timestamp_bigint_0Func,
-    CURRENT_TIMESTAMP_BIGINT_0,
-    current_timestamp_bigint_0
-);
-make_udf_function!(
-    current_timestamp_impl::current_timestamp_bigint_3Func,
-    CURRENT_TIMESTAMP_BIGINT_3,
-    current_timestamp_bigint_3
-);
-make_udf_function!(
-    current_timestamp_impl::current_timestamp_bigint_6Func,
-    CURRENT_TIMESTAMP_BIGINT_6,
-    current_timestamp_bigint_6
-);
-make_udf_function!(
-    current_timestamp_impl::current_timestamp_bigint_9Func,
-    CURRENT_TIMESTAMP_BIGINT_9,
-    current_timestamp_bigint_9
-);
+make_udf_function!(current_timestamp_impl::current_timestampFunc, CURRENT_TIMESTAMP, current_timestamp);
+make_udf_function!(current_timestamp_impl::current_timestamp_bigint_0Func, CURRENT_TIMESTAMP_BIGINT_0, current_timestamp_bigint_0);
+make_udf_function!(current_timestamp_impl::current_timestamp_bigint_3Func, CURRENT_TIMESTAMP_BIGINT_3, current_timestamp_bigint_3);
+make_udf_function!(current_timestamp_impl::current_timestamp_bigint_6Func, CURRENT_TIMESTAMP_BIGINT_6, current_timestamp_bigint_6);
+make_udf_function!(current_timestamp_impl::current_timestamp_bigint_9Func, CURRENT_TIMESTAMP_BIGINT_9, current_timestamp_bigint_9);
 
-make_udf_function!(
-    current_timezone_impl::current_timezoneFunc,
-    CURRENT_TIMEZONE,
-    current_timezone
-);
+make_udf_function!(current_timezone_impl::current_timezoneFunc, CURRENT_TIMEZONE, current_timezone);
 
-make_udf_function!(
-    current_user_impl::current_userFunc,
-    CURRENT_USER,
-    current_user
-);
+make_udf_function!(current_user_impl::current_userFunc, CURRENT_USER, current_user);
 
-make_udf_function!(
-    date_impl::date_timestamp_pFunc,
-    DATE_TIMESTAMP_P,
-    date_timestamp_p
-);
+make_udf_function!(date_impl::date_timestamp_pFunc, DATE_TIMESTAMP_P, date_timestamp_p);
 make_udf_function!(date_impl::date_varcharFunc, DATE_VARCHAR, date_varchar);
 
-make_udf_function!(
-    date_add_impl::date_add_varchar_bigint_dateFunc,
-    DATE_ADD_VARCHAR_BIGINT_DATE,
-    date_add_varchar_bigint_date
-);
-make_udf_function!(
-    date_add_impl::date_add_varchar_bigint_time_pFunc,
-    DATE_ADD_VARCHAR_BIGINT_TIME_P,
-    date_add_varchar_bigint_time_p
-);
-make_udf_function!(
-    date_add_impl::date_add_varchar_bigint_timestamp_pFunc,
-    DATE_ADD_VARCHAR_BIGINT_TIMESTAMP_P,
-    date_add_varchar_bigint_timestamp_p
-);
+make_udf_function!(date_add_impl::date_add_varchar_bigint_dateFunc, DATE_ADD_VARCHAR_BIGINT_DATE, date_add_varchar_bigint_date);
+make_udf_function!(date_add_impl::date_add_varchar_bigint_time_pFunc, DATE_ADD_VARCHAR_BIGINT_TIME_P, date_add_varchar_bigint_time_p);
+make_udf_function!(date_add_impl::date_add_varchar_bigint_timestamp_pFunc, DATE_ADD_VARCHAR_BIGINT_TIMESTAMP_P, date_add_varchar_bigint_timestamp_p);
 
-make_udf_function!(
-    date_diff_impl::date_diff_varchar_date_dateFunc,
-    DATE_DIFF_VARCHAR_DATE_DATE,
-    date_diff_varchar_date_date
-);
-make_udf_function!(
-    date_diff_impl::date_diff_varchar_time_p_time_pFunc,
-    DATE_DIFF_VARCHAR_TIME_P_TIME_P,
-    date_diff_varchar_time_p_time_p
-);
-make_udf_function!(
-    date_diff_impl::date_diff_varchar_timestamp_p_timestamp_pFunc,
-    DATE_DIFF_VARCHAR_TIMESTAMP_P_TIMESTAMP_P,
-    date_diff_varchar_timestamp_p_timestamp_p
-);
+make_udf_function!(date_diff_impl::date_diff_varchar_date_dateFunc, DATE_DIFF_VARCHAR_DATE_DATE, date_diff_varchar_date_date);
+make_udf_function!(date_diff_impl::date_diff_varchar_time_p_time_pFunc, DATE_DIFF_VARCHAR_TIME_P_TIME_P, date_diff_varchar_time_p_time_p);
+make_udf_function!(date_diff_impl::date_diff_varchar_timestamp_p_timestamp_pFunc, DATE_DIFF_VARCHAR_TIMESTAMP_P_TIMESTAMP_P, date_diff_varchar_timestamp_p_timestamp_p);
 
-make_udf_function!(
-    date_format_impl::date_format_timestamp_p_varcharFunc,
-    DATE_FORMAT_TIMESTAMP_P_VARCHAR,
-    date_format_timestamp_p_varchar
-);
+make_udf_function!(date_format_impl::date_format_timestamp_p_varcharFunc, DATE_FORMAT_TIMESTAMP_P_VARCHAR, date_format_timestamp_p_varchar);
 
-make_udf_function!(
-    date_parse_impl::date_parse_varchar_varcharFunc,
-    DATE_PARSE_VARCHAR_VARCHAR,
-    date_parse_varchar_varchar
-);
+make_udf_function!(date_parse_impl::date_parse_varchar_varcharFunc, DATE_PARSE_VARCHAR_VARCHAR, date_parse_varchar_varchar);
 
-make_udf_function!(
-    date_trunc_impl::date_trunc_varchar_time_pFunc,
-    DATE_TRUNC_VARCHAR_TIME_P,
-    date_trunc_varchar_time_p
-);
-make_udf_function!(
-    date_trunc_impl::date_trunc_varchar_timestamp_pFunc,
-    DATE_TRUNC_VARCHAR_TIMESTAMP_P,
-    date_trunc_varchar_timestamp_p
-);
-make_udf_function!(
-    date_trunc_impl::date_trunc_varchar_dateFunc,
-    DATE_TRUNC_VARCHAR_DATE,
-    date_trunc_varchar_date
-);
+make_udf_function!(date_trunc_impl::date_trunc_varchar_time_pFunc, DATE_TRUNC_VARCHAR_TIME_P, date_trunc_varchar_time_p);
+make_udf_function!(date_trunc_impl::date_trunc_varchar_timestamp_pFunc, DATE_TRUNC_VARCHAR_TIMESTAMP_P, date_trunc_varchar_timestamp_p);
+make_udf_function!(date_trunc_impl::date_trunc_varchar_dateFunc, DATE_TRUNC_VARCHAR_DATE, date_trunc_varchar_date);
 
 make_udf_function!(day_impl::day_dateFunc, DAY_DATE, day_date);
-make_udf_function!(
-    day_impl::day_intervaldaytosecondFunc,
-    DAY_INTERVALDAYTOSECOND,
-    day_intervaldaytosecond
-);
-make_udf_function!(
-    day_impl::day_timestamp_pFunc,
-    DAY_TIMESTAMP_P,
-    day_timestamp_p
-);
+make_udf_function!(day_impl::day_intervaldaytosecondFunc, DAY_INTERVALDAYTOSECOND, day_intervaldaytosecond);
+make_udf_function!(day_impl::day_timestamp_pFunc, DAY_TIMESTAMP_P, day_timestamp_p);
 
-make_udf_function!(
-    day_of_month_impl::day_of_month_dateFunc,
-    DAY_OF_MONTH_DATE,
-    day_of_month_date
-);
-make_udf_function!(
-    day_of_month_impl::day_of_month_intervaldaytosecondFunc,
-    DAY_OF_MONTH_INTERVALDAYTOSECOND,
-    day_of_month_intervaldaytosecond
-);
-make_udf_function!(
-    day_of_month_impl::day_of_month_timestamp_pFunc,
-    DAY_OF_MONTH_TIMESTAMP_P,
-    day_of_month_timestamp_p
-);
+make_udf_function!(day_of_month_impl::day_of_month_dateFunc, DAY_OF_MONTH_DATE, day_of_month_date);
+make_udf_function!(day_of_month_impl::day_of_month_intervaldaytosecondFunc, DAY_OF_MONTH_INTERVALDAYTOSECOND, day_of_month_intervaldaytosecond);
+make_udf_function!(day_of_month_impl::day_of_month_timestamp_pFunc, DAY_OF_MONTH_TIMESTAMP_P, day_of_month_timestamp_p);
 
-make_udf_function!(
-    day_of_week_impl::day_of_week_dateFunc,
-    DAY_OF_WEEK_DATE,
-    day_of_week_date
-);
-make_udf_function!(
-    day_of_week_impl::day_of_week_timestamp_pFunc,
-    DAY_OF_WEEK_TIMESTAMP_P,
-    day_of_week_timestamp_p
-);
+make_udf_function!(day_of_week_impl::day_of_week_dateFunc, DAY_OF_WEEK_DATE, day_of_week_date);
+make_udf_function!(day_of_week_impl::day_of_week_timestamp_pFunc, DAY_OF_WEEK_TIMESTAMP_P, day_of_week_timestamp_p);
 
-make_udf_function!(
-    day_of_year_impl::day_of_year_dateFunc,
-    DAY_OF_YEAR_DATE,
-    day_of_year_date
-);
-make_udf_function!(
-    day_of_year_impl::day_of_year_timestamp_pFunc,
-    DAY_OF_YEAR_TIMESTAMP_P,
-    day_of_year_timestamp_p
-);
+make_udf_function!(day_of_year_impl::day_of_year_dateFunc, DAY_OF_YEAR_DATE, day_of_year_date);
+make_udf_function!(day_of_year_impl::day_of_year_timestamp_pFunc, DAY_OF_YEAR_TIMESTAMP_P, day_of_year_timestamp_p);
 
-make_udf_function!(
-    degrees_impl::degrees_doubleFunc,
-    DEGREES_DOUBLE,
-    degrees_double
-);
+make_udf_function!(degrees_impl::degrees_doubleFunc, DEGREES_DOUBLE, degrees_double);
 
 make_udf_function!(dow_impl::dow_dateFunc, DOW_DATE, dow_date);
-make_udf_function!(
-    dow_impl::dow_timestamp_pFunc,
-    DOW_TIMESTAMP_P,
-    dow_timestamp_p
-);
+make_udf_function!(dow_impl::dow_timestamp_pFunc, DOW_TIMESTAMP_P, dow_timestamp_p);
 
 make_udf_function!(doy_impl::doy_dateFunc, DOY_DATE, doy_date);
-make_udf_function!(
-    doy_impl::doy_timestamp_pFunc,
-    DOY_TIMESTAMP_P,
-    doy_timestamp_p
-);
+make_udf_function!(doy_impl::doy_timestamp_pFunc, DOY_TIMESTAMP_P, doy_timestamp_p);
 
 make_udf_function!(e_impl::eFunc, E, e);
 
-make_udf_function!(
-    element_at_impl::element_at_map_4_5_4Func,
-    ELEMENT_AT_MAP_4_5_4,
-    element_at_map_4_5_4
-);
-make_udf_function!(
-    element_at_impl::element_at_array_3_bigintFunc,
-    ELEMENT_AT_ARRAY_3_BIGINT,
-    element_at_array_3_bigint
-);
+make_udf_function!(element_at_impl::element_at_map_4_5_4Func, ELEMENT_AT_MAP_4_5_4, element_at_map_4_5_4);
+make_udf_function!(element_at_impl::element_at_array_3_bigintFunc, ELEMENT_AT_ARRAY_3_BIGINT, element_at_array_3_bigint);
 
-make_udf_function!(
-    empty_approx_set_impl::empty_approx_setFunc,
-    EMPTY_APPROX_SET,
-    empty_approx_set
-);
+make_udf_function!(empty_approx_set_impl::empty_approx_setFunc, EMPTY_APPROX_SET, empty_approx_set);
 
 make_udf_function!(exp_impl::exp_doubleFunc, EXP_DOUBLE, exp_double);
 
-make_udf_function!(
-    features_impl::features_doubleFunc,
-    FEATURES_DOUBLE,
-    features_double
-);
-make_udf_function!(
-    features_impl::features_double_doubleFunc,
-    FEATURES_DOUBLE_DOUBLE,
-    features_double_double
-);
-make_udf_function!(
-    features_impl::features_double_double_doubleFunc,
-    FEATURES_DOUBLE_DOUBLE_DOUBLE,
-    features_double_double_double
-);
-make_udf_function!(
-    features_impl::features_double_double_double_doubleFunc,
-    FEATURES_DOUBLE_DOUBLE_DOUBLE_DOUBLE,
-    features_double_double_double_double
-);
-make_udf_function!(
-    features_impl::features_double_double_double_double_doubleFunc,
-    FEATURES_DOUBLE_DOUBLE_DOUBLE_DOUBLE_DOUBLE,
-    features_double_double_double_double_double
-);
-make_udf_function!(
-    features_impl::features_double_double_double_double_double_doubleFunc,
-    FEATURES_DOUBLE_DOUBLE_DOUBLE_DOUBLE_DOUBLE_DOUBLE,
-    features_double_double_double_double_double_double
-);
-make_udf_function!(
-    features_impl::features_double_double_double_double_double_double_doubleFunc,
-    FEATURES_DOUBLE_DOUBLE_DOUBLE_DOUBLE_DOUBLE_DOUBLE_DOUBLE,
-    features_double_double_double_double_double_double_double
-);
-make_udf_function!(
-    features_impl::features_double_double_double_double_double_double_double_doubleFunc,
-    FEATURES_DOUBLE_DOUBLE_DOUBLE_DOUBLE_DOUBLE_DOUBLE_DOUBLE_DOUBLE,
-    features_double_double_double_double_double_double_double_double
-);
-make_udf_function!(
-    features_impl::features_double_double_double_double_double_double_double_double_doubleFunc,
-    FEATURES_DOUBLE_DOUBLE_DOUBLE_DOUBLE_DOUBLE_DOUBLE_DOUBLE_DOUBLE_DOUBLE,
-    features_double_double_double_double_double_double_double_double_double
-);
+make_udf_function!(features_impl::features_doubleFunc, FEATURES_DOUBLE, features_double);
+make_udf_function!(features_impl::features_double_doubleFunc, FEATURES_DOUBLE_DOUBLE, features_double_double);
+make_udf_function!(features_impl::features_double_double_doubleFunc, FEATURES_DOUBLE_DOUBLE_DOUBLE, features_double_double_double);
+make_udf_function!(features_impl::features_double_double_double_doubleFunc, FEATURES_DOUBLE_DOUBLE_DOUBLE_DOUBLE, features_double_double_double_double);
+make_udf_function!(features_impl::features_double_double_double_double_doubleFunc, FEATURES_DOUBLE_DOUBLE_DOUBLE_DOUBLE_DOUBLE, features_double_double_double_double_double);
+make_udf_function!(features_impl::features_double_double_double_double_double_doubleFunc, FEATURES_DOUBLE_DOUBLE_DOUBLE_DOUBLE_DOUBLE_DOUBLE, features_double_double_double_double_double_double);
+make_udf_function!(features_impl::features_double_double_double_double_double_double_doubleFunc, FEATURES_DOUBLE_DOUBLE_DOUBLE_DOUBLE_DOUBLE_DOUBLE_DOUBLE, features_double_double_double_double_double_double_double);
+make_udf_function!(features_impl::features_double_double_double_double_double_double_double_doubleFunc, FEATURES_DOUBLE_DOUBLE_DOUBLE_DOUBLE_DOUBLE_DOUBLE_DOUBLE_DOUBLE, features_double_double_double_double_double_double_double_double);
+make_udf_function!(features_impl::features_double_double_double_double_double_double_double_double_doubleFunc, FEATURES_DOUBLE_DOUBLE_DOUBLE_DOUBLE_DOUBLE_DOUBLE_DOUBLE_DOUBLE_DOUBLE, features_double_double_double_double_double_double_double_double_double);
 make_udf_function!(features_impl::features_double_double_double_double_double_double_double_double_double_doubleFunc, FEATURES_DOUBLE_DOUBLE_DOUBLE_DOUBLE_DOUBLE_DOUBLE_DOUBLE_DOUBLE_DOUBLE_DOUBLE, features_double_double_double_double_double_double_double_double_double_double);
 
-make_udf_function!(
-    filter_impl::filter_array_1_function_1_booleanFunc,
-    FILTER_ARRAY_1_FUNCTION_1_BOOLEAN,
-    filter_array_1_function_1_boolean
-);
+make_udf_function!(filter_impl::filter_array_1_function_1_booleanFunc, FILTER_ARRAY_1_FUNCTION_1_BOOLEAN, filter_array_1_function_1_boolean);
 
-make_udf_function!(
-    flatten_impl::flatten_array_array_3Func,
-    FLATTEN_ARRAY_ARRAY_3,
-    flatten_array_array_3
-);
+make_udf_function!(flatten_impl::flatten_array_array_3Func, FLATTEN_ARRAY_ARRAY_3, flatten_array_array_3);
 
 make_udf_function!(floor_impl::floor_bigintFunc, FLOOR_BIGINT, floor_bigint);
-make_udf_function!(
-    floor_impl::floor_decimal_p_sFunc,
-    FLOOR_DECIMAL_P_S,
-    floor_decimal_p_s
-);
+make_udf_function!(floor_impl::floor_decimal_p_sFunc, FLOOR_DECIMAL_P_S, floor_decimal_p_s);
 make_udf_function!(floor_impl::floor_doubleFunc, FLOOR_DOUBLE, floor_double);
 make_udf_function!(floor_impl::floor_integerFunc, FLOOR_INTEGER, floor_integer);
 make_udf_function!(floor_impl::floor_realFunc, FLOOR_REAL, floor_real);
-make_udf_function!(
-    floor_impl::floor_smallintFunc,
-    FLOOR_SMALLINT,
-    floor_smallint
-);
+make_udf_function!(floor_impl::floor_smallintFunc, FLOOR_SMALLINT, floor_smallint);
 make_udf_function!(floor_impl::floor_tinyintFunc, FLOOR_TINYINT, floor_tinyint);
 
-make_udf_function!(
-    format_impl::format_varchar_1Func,
-    FORMAT_VARCHAR_1,
-    format_varchar_1
-);
-make_udf_function!(
-    format_impl::format_varchar_1_2Func,
-    FORMAT_VARCHAR_1_2,
-    format_varchar_1_2
-);
-make_udf_function!(
-    format_impl::format_varchar_1_2_3Func,
-    FORMAT_VARCHAR_1_2_3,
-    format_varchar_1_2_3
-);
-make_udf_function!(
-    format_impl::format_varchar_1_2_3_4Func,
-    FORMAT_VARCHAR_1_2_3_4,
-    format_varchar_1_2_3_4
-);
-make_udf_function!(
-    format_impl::format_varchar_1_2_3_4_5Func,
-    FORMAT_VARCHAR_1_2_3_4_5,
-    format_varchar_1_2_3_4_5
-);
+make_udf_function!(format_impl::format_varchar_1Func, FORMAT_VARCHAR_1, format_varchar_1);
+make_udf_function!(format_impl::format_varchar_1_2Func, FORMAT_VARCHAR_1_2, format_varchar_1_2);
+make_udf_function!(format_impl::format_varchar_1_2_3Func, FORMAT_VARCHAR_1_2_3, format_varchar_1_2_3);
+make_udf_function!(format_impl::format_varchar_1_2_3_4Func, FORMAT_VARCHAR_1_2_3_4, format_varchar_1_2_3_4);
+make_udf_function!(format_impl::format_varchar_1_2_3_4_5Func, FORMAT_VARCHAR_1_2_3_4_5, format_varchar_1_2_3_4_5);
 
-make_udf_function!(
-    format_datetime_impl::format_datetime_timestamp_p_varcharFunc,
-    FORMAT_DATETIME_TIMESTAMP_P_VARCHAR,
-    format_datetime_timestamp_p_varchar
-);
+make_udf_function!(format_datetime_impl::format_datetime_timestamp_p_varcharFunc, FORMAT_DATETIME_TIMESTAMP_P_VARCHAR, format_datetime_timestamp_p_varchar);
 
-make_udf_function!(
-    format_number_impl::format_number_bigintFunc,
-    FORMAT_NUMBER_BIGINT,
-    format_number_bigint
-);
-make_udf_function!(
-    format_number_impl::format_number_doubleFunc,
-    FORMAT_NUMBER_DOUBLE,
-    format_number_double
-);
+make_udf_function!(format_number_impl::format_number_bigintFunc, FORMAT_NUMBER_BIGINT, format_number_bigint);
+make_udf_function!(format_number_impl::format_number_doubleFunc, FORMAT_NUMBER_DOUBLE, format_number_double);
 
-make_udf_function!(
-    from_base_impl::from_base_varchar_bigintFunc,
-    FROM_BASE_VARCHAR_BIGINT,
-    from_base_varchar_bigint
-);
+make_udf_function!(from_base_impl::from_base_varchar_bigintFunc, FROM_BASE_VARCHAR_BIGINT, from_base_varchar_bigint);
 
-make_udf_function!(
-    from_base32_impl::from_base32_varbinaryFunc,
-    FROM_BASE32_VARBINARY,
-    from_base32_varbinary
-);
-make_udf_function!(
-    from_base32_impl::from_base32_varcharFunc,
-    FROM_BASE32_VARCHAR,
-    from_base32_varchar
-);
+make_udf_function!(from_base32_impl::from_base32_varbinaryFunc, FROM_BASE32_VARBINARY, from_base32_varbinary);
+make_udf_function!(from_base32_impl::from_base32_varcharFunc, FROM_BASE32_VARCHAR, from_base32_varchar);
 
-make_udf_function!(
-    from_base64_impl::from_base64_varbinaryFunc,
-    FROM_BASE64_VARBINARY,
-    from_base64_varbinary
-);
-make_udf_function!(
-    from_base64_impl::from_base64_varcharFunc,
-    FROM_BASE64_VARCHAR,
-    from_base64_varchar
-);
+make_udf_function!(from_base64_impl::from_base64_varbinaryFunc, FROM_BASE64_VARBINARY, from_base64_varbinary);
+make_udf_function!(from_base64_impl::from_base64_varcharFunc, FROM_BASE64_VARCHAR, from_base64_varchar);
 
-make_udf_function!(
-    from_base64url_impl::from_base64url_varbinaryFunc,
-    FROM_BASE64URL_VARBINARY,
-    from_base64url_varbinary
-);
-make_udf_function!(
-    from_base64url_impl::from_base64url_varcharFunc,
-    FROM_BASE64URL_VARCHAR,
-    from_base64url_varchar
-);
+make_udf_function!(from_base64url_impl::from_base64url_varbinaryFunc, FROM_BASE64URL_VARBINARY, from_base64url_varbinary);
+make_udf_function!(from_base64url_impl::from_base64url_varcharFunc, FROM_BASE64URL_VARCHAR, from_base64url_varchar);
 
-make_udf_function!(
-    from_big_endian_32_impl::from_big_endian_32_varbinaryFunc,
-    FROM_BIG_ENDIAN_32_VARBINARY,
-    from_big_endian_32_varbinary
-);
+make_udf_function!(from_big_endian_32_impl::from_big_endian_32_varbinaryFunc, FROM_BIG_ENDIAN_32_VARBINARY, from_big_endian_32_varbinary);
 
-make_udf_function!(
-    from_big_endian_64_impl::from_big_endian_64_varbinaryFunc,
-    FROM_BIG_ENDIAN_64_VARBINARY,
-    from_big_endian_64_varbinary
-);
+make_udf_function!(from_big_endian_64_impl::from_big_endian_64_varbinaryFunc, FROM_BIG_ENDIAN_64_VARBINARY, from_big_endian_64_varbinary);
 
-make_udf_function!(
-    from_encoded_polyline_impl::from_encoded_polyline_varcharFunc,
-    FROM_ENCODED_POLYLINE_VARCHAR,
-    from_encoded_polyline_varchar
-);
+make_udf_function!(from_encoded_polyline_impl::from_encoded_polyline_varcharFunc, FROM_ENCODED_POLYLINE_VARCHAR, from_encoded_polyline_varchar);
 
-make_udf_function!(
-    from_geojson_geometry_impl::from_geojson_geometry_varcharFunc,
-    FROM_GEOJSON_GEOMETRY_VARCHAR,
-    from_geojson_geometry_varchar
-);
+make_udf_function!(from_geojson_geometry_impl::from_geojson_geometry_varcharFunc, FROM_GEOJSON_GEOMETRY_VARCHAR, from_geojson_geometry_varchar);
 
-make_udf_function!(
-    from_hex_impl::from_hex_varbinaryFunc,
-    FROM_HEX_VARBINARY,
-    from_hex_varbinary
-);
-make_udf_function!(
-    from_hex_impl::from_hex_varcharFunc,
-    FROM_HEX_VARCHAR,
-    from_hex_varchar
-);
+make_udf_function!(from_hex_impl::from_hex_varbinaryFunc, FROM_HEX_VARBINARY, from_hex_varbinary);
+make_udf_function!(from_hex_impl::from_hex_varcharFunc, FROM_HEX_VARCHAR, from_hex_varchar);
 
-make_udf_function!(
-    from_ieee754_32_impl::from_ieee754_32_varbinaryFunc,
-    FROM_IEEE754_32_VARBINARY,
-    from_ieee754_32_varbinary
-);
+make_udf_function!(from_ieee754_32_impl::from_ieee754_32_varbinaryFunc, FROM_IEEE754_32_VARBINARY, from_ieee754_32_varbinary);
 
-make_udf_function!(
-    from_ieee754_64_impl::from_ieee754_64_varbinaryFunc,
-    FROM_IEEE754_64_VARBINARY,
-    from_ieee754_64_varbinary
-);
+make_udf_function!(from_ieee754_64_impl::from_ieee754_64_varbinaryFunc, FROM_IEEE754_64_VARBINARY, from_ieee754_64_varbinary);
 
-make_udf_function!(
-    from_iso8601_date_impl::from_iso8601_date_varcharFunc,
-    FROM_ISO8601_DATE_VARCHAR,
-    from_iso8601_date_varchar
-);
+make_udf_function!(from_iso8601_date_impl::from_iso8601_date_varcharFunc, FROM_ISO8601_DATE_VARCHAR, from_iso8601_date_varchar);
 
-make_udf_function!(
-    from_iso8601_timestamp_impl::from_iso8601_timestamp_varcharFunc,
-    FROM_ISO8601_TIMESTAMP_VARCHAR,
-    from_iso8601_timestamp_varchar
-);
+make_udf_function!(from_iso8601_timestamp_impl::from_iso8601_timestamp_varcharFunc, FROM_ISO8601_TIMESTAMP_VARCHAR, from_iso8601_timestamp_varchar);
 
-make_udf_function!(
-    from_iso8601_timestamp_nanos_impl::from_iso8601_timestamp_nanos_varcharFunc,
-    FROM_ISO8601_TIMESTAMP_NANOS_VARCHAR,
-    from_iso8601_timestamp_nanos_varchar
-);
+make_udf_function!(from_iso8601_timestamp_nanos_impl::from_iso8601_timestamp_nanos_varcharFunc, FROM_ISO8601_TIMESTAMP_NANOS_VARCHAR, from_iso8601_timestamp_nanos_varchar);
 
-make_udf_function!(
-    from_unixtime_impl::from_unixtime_bigintFunc,
-    FROM_UNIXTIME_BIGINT,
-    from_unixtime_bigint
-);
-make_udf_function!(
-    from_unixtime_impl::from_unixtime_bigint_bigint_bigintFunc,
-    FROM_UNIXTIME_BIGINT_BIGINT_BIGINT,
-    from_unixtime_bigint_bigint_bigint
-);
-make_udf_function!(
-    from_unixtime_impl::from_unixtime_bigint_varcharFunc,
-    FROM_UNIXTIME_BIGINT_VARCHAR,
-    from_unixtime_bigint_varchar
-);
+make_udf_function!(from_unixtime_impl::from_unixtime_bigintFunc, FROM_UNIXTIME_BIGINT, from_unixtime_bigint);
+make_udf_function!(from_unixtime_impl::from_unixtime_bigint_bigint_bigintFunc, FROM_UNIXTIME_BIGINT_BIGINT_BIGINT, from_unixtime_bigint_bigint_bigint);
+make_udf_function!(from_unixtime_impl::from_unixtime_bigint_varcharFunc, FROM_UNIXTIME_BIGINT_VARCHAR, from_unixtime_bigint_varchar);
 
-make_udf_function!(
-    from_unixtime_nanos_impl::from_unixtime_nanos_bigintFunc,
-    FROM_UNIXTIME_NANOS_BIGINT,
-    from_unixtime_nanos_bigint
-);
-make_udf_function!(
-    from_unixtime_nanos_impl::from_unixtime_nanos_decimal_p_sFunc,
-    FROM_UNIXTIME_NANOS_DECIMAL_P_S,
-    from_unixtime_nanos_decimal_p_s
-);
+make_udf_function!(from_unixtime_nanos_impl::from_unixtime_nanos_bigintFunc, FROM_UNIXTIME_NANOS_BIGINT, from_unixtime_nanos_bigint);
+make_udf_function!(from_unixtime_nanos_impl::from_unixtime_nanos_decimal_p_sFunc, FROM_UNIXTIME_NANOS_DECIMAL_P_S, from_unixtime_nanos_decimal_p_s);
 
-make_udf_function!(
-    from_utf8_impl::from_utf8_varbinaryFunc,
-    FROM_UTF8_VARBINARY,
-    from_utf8_varbinary
-);
-make_udf_function!(
-    from_utf8_impl::from_utf8_varbinary_bigintFunc,
-    FROM_UTF8_VARBINARY_BIGINT,
-    from_utf8_varbinary_bigint
-);
-make_udf_function!(
-    from_utf8_impl::from_utf8_varbinary_varcharFunc,
-    FROM_UTF8_VARBINARY_VARCHAR,
-    from_utf8_varbinary_varchar
-);
+make_udf_function!(from_utf8_impl::from_utf8_varbinaryFunc, FROM_UTF8_VARBINARY, from_utf8_varbinary);
+make_udf_function!(from_utf8_impl::from_utf8_varbinary_bigintFunc, FROM_UTF8_VARBINARY_BIGINT, from_utf8_varbinary_bigint);
+make_udf_function!(from_utf8_impl::from_utf8_varbinary_varcharFunc, FROM_UTF8_VARBINARY_VARCHAR, from_utf8_varbinary_varchar);
 
-make_udf_function!(
-    geometry_from_hadoop_shape_impl::geometry_from_hadoop_shape_varbinaryFunc,
-    GEOMETRY_FROM_HADOOP_SHAPE_VARBINARY,
-    geometry_from_hadoop_shape_varbinary
-);
+make_udf_function!(geometry_from_hadoop_shape_impl::geometry_from_hadoop_shape_varbinaryFunc, GEOMETRY_FROM_HADOOP_SHAPE_VARBINARY, geometry_from_hadoop_shape_varbinary);
 
-make_udf_function!(
-    geometry_invalid_reason_impl::geometry_invalid_reason_geometryFunc,
-    GEOMETRY_INVALID_REASON_GEOMETRY,
-    geometry_invalid_reason_geometry
-);
+make_udf_function!(geometry_invalid_reason_impl::geometry_invalid_reason_geometryFunc, GEOMETRY_INVALID_REASON_GEOMETRY, geometry_invalid_reason_geometry);
 
-make_udf_function!(
-    geometry_nearest_points_impl::geometry_nearest_points_geometry_geometryFunc,
-    GEOMETRY_NEAREST_POINTS_GEOMETRY_GEOMETRY,
-    geometry_nearest_points_geometry_geometry
-);
+make_udf_function!(geometry_nearest_points_impl::geometry_nearest_points_geometry_geometryFunc, GEOMETRY_NEAREST_POINTS_GEOMETRY_GEOMETRY, geometry_nearest_points_geometry_geometry);
 
-make_udf_function!(
-    geometry_to_bing_tiles_impl::geometry_to_bing_tiles_geometry_bigintFunc,
-    GEOMETRY_TO_BING_TILES_GEOMETRY_BIGINT,
-    geometry_to_bing_tiles_geometry_bigint
-);
+make_udf_function!(geometry_to_bing_tiles_impl::geometry_to_bing_tiles_geometry_bigintFunc, GEOMETRY_TO_BING_TILES_GEOMETRY_BIGINT, geometry_to_bing_tiles_geometry_bigint);
 
-make_udf_function!(
-    geometry_union_impl::geometry_union_array_geometryFunc,
-    GEOMETRY_UNION_ARRAY_GEOMETRY,
-    geometry_union_array_geometry
-);
+make_udf_function!(geometry_union_impl::geometry_union_array_geometryFunc, GEOMETRY_UNION_ARRAY_GEOMETRY, geometry_union_array_geometry);
 
-make_udf_function!(
-    great_circle_distance_impl::great_circle_distance_double_double_double_doubleFunc,
-    GREAT_CIRCLE_DISTANCE_DOUBLE_DOUBLE_DOUBLE_DOUBLE,
-    great_circle_distance_double_double_double_double
-);
+make_udf_function!(great_circle_distance_impl::great_circle_distance_double_double_double_doubleFunc, GREAT_CIRCLE_DISTANCE_DOUBLE_DOUBLE_DOUBLE_DOUBLE, great_circle_distance_double_double_double_double);
 
 make_udf_function!(greatest_impl::greatest_3Func, GREATEST_3, greatest_3);
 
-make_udf_function!(
-    hamming_distance_impl::hamming_distance_varchar_varcharFunc,
-    HAMMING_DISTANCE_VARCHAR_VARCHAR,
-    hamming_distance_varchar_varchar
-);
+make_udf_function!(hamming_distance_impl::hamming_distance_varchar_varcharFunc, HAMMING_DISTANCE_VARCHAR_VARCHAR, hamming_distance_varchar_varchar);
 
-make_udf_function!(
-    hash_counts_impl::hash_counts_setdigestFunc,
-    HASH_COUNTS_SETDIGEST,
-    hash_counts_setdigest
-);
+make_udf_function!(hash_counts_impl::hash_counts_setdigestFunc, HASH_COUNTS_SETDIGEST, hash_counts_setdigest);
 
-make_udf_function!(
-    hmac_md5_impl::hmac_md5_varbinary_varbinaryFunc,
-    HMAC_MD5_VARBINARY_VARBINARY,
-    hmac_md5_varbinary_varbinary
-);
+make_udf_function!(hmac_md5_impl::hmac_md5_varbinary_varbinaryFunc, HMAC_MD5_VARBINARY_VARBINARY, hmac_md5_varbinary_varbinary);
 
-make_udf_function!(
-    hmac_sha1_impl::hmac_sha1_varbinary_varbinaryFunc,
-    HMAC_SHA1_VARBINARY_VARBINARY,
-    hmac_sha1_varbinary_varbinary
-);
+make_udf_function!(hmac_sha1_impl::hmac_sha1_varbinary_varbinaryFunc, HMAC_SHA1_VARBINARY_VARBINARY, hmac_sha1_varbinary_varbinary);
 
-make_udf_function!(
-    hmac_sha256_impl::hmac_sha256_varbinary_varbinaryFunc,
-    HMAC_SHA256_VARBINARY_VARBINARY,
-    hmac_sha256_varbinary_varbinary
-);
+make_udf_function!(hmac_sha256_impl::hmac_sha256_varbinary_varbinaryFunc, HMAC_SHA256_VARBINARY_VARBINARY, hmac_sha256_varbinary_varbinary);
 
-make_udf_function!(
-    hmac_sha512_impl::hmac_sha512_varbinary_varbinaryFunc,
-    HMAC_SHA512_VARBINARY_VARBINARY,
-    hmac_sha512_varbinary_varbinary
-);
+make_udf_function!(hmac_sha512_impl::hmac_sha512_varbinary_varbinaryFunc, HMAC_SHA512_VARBINARY_VARBINARY, hmac_sha512_varbinary_varbinary);
 
-make_udf_function!(
-    hour_impl::hour_intervaldaytosecondFunc,
-    HOUR_INTERVALDAYTOSECOND,
-    hour_intervaldaytosecond
-);
+make_udf_function!(hour_impl::hour_intervaldaytosecondFunc, HOUR_INTERVALDAYTOSECOND, hour_intervaldaytosecond);
 make_udf_function!(hour_impl::hour_time_pFunc, HOUR_TIME_P, hour_time_p);
-make_udf_function!(
-    hour_impl::hour_timestamp_pFunc,
-    HOUR_TIMESTAMP_P,
-    hour_timestamp_p
-);
+make_udf_function!(hour_impl::hour_timestamp_pFunc, HOUR_TIMESTAMP_P, hour_timestamp_p);
 
-make_udf_function!(
-    human_readable_seconds_impl::human_readable_seconds_doubleFunc,
-    HUMAN_READABLE_SECONDS_DOUBLE,
-    human_readable_seconds_double
-);
+make_udf_function!(human_readable_seconds_impl::human_readable_seconds_doubleFunc, HUMAN_READABLE_SECONDS_DOUBLE, human_readable_seconds_double);
 
 make_udf_function!(if_impl::if_boolean_1_1Func, IF_BOOLEAN_1_1, if_boolean_1_1);
 
-make_udf_function!(
-    index_impl::index_varchar_varcharFunc,
-    INDEX_VARCHAR_VARCHAR,
-    index_varchar_varchar
-);
+make_udf_function!(index_impl::index_varchar_varcharFunc, INDEX_VARCHAR_VARCHAR, index_varchar_varchar);
 
 make_udf_function!(infinity_impl::infinityFunc, INFINITY, infinity);
 
-make_udf_function!(
-    intersection_cardinality_impl::intersection_cardinality_setdigest_setdigestFunc,
-    INTERSECTION_CARDINALITY_SETDIGEST_SETDIGEST,
-    intersection_cardinality_setdigest_setdigest
-);
+make_udf_function!(intersection_cardinality_impl::intersection_cardinality_setdigest_setdigestFunc, INTERSECTION_CARDINALITY_SETDIGEST_SETDIGEST, intersection_cardinality_setdigest_setdigest);
 
-make_udf_function!(
-    inverse_beta_cdf_impl::inverse_beta_cdf_double_double_doubleFunc,
-    INVERSE_BETA_CDF_DOUBLE_DOUBLE_DOUBLE,
-    inverse_beta_cdf_double_double_double
-);
+make_udf_function!(inverse_beta_cdf_impl::inverse_beta_cdf_double_double_doubleFunc, INVERSE_BETA_CDF_DOUBLE_DOUBLE_DOUBLE, inverse_beta_cdf_double_double_double);
 
-make_udf_function!(
-    inverse_normal_cdf_impl::inverse_normal_cdf_double_double_doubleFunc,
-    INVERSE_NORMAL_CDF_DOUBLE_DOUBLE_DOUBLE,
-    inverse_normal_cdf_double_double_double
-);
+make_udf_function!(inverse_normal_cdf_impl::inverse_normal_cdf_double_double_doubleFunc, INVERSE_NORMAL_CDF_DOUBLE_DOUBLE_DOUBLE, inverse_normal_cdf_double_double_double);
 
-make_udf_function!(
-    is_finite_impl::is_finite_doubleFunc,
-    IS_FINITE_DOUBLE,
-    is_finite_double
-);
+make_udf_function!(is_finite_impl::is_finite_doubleFunc, IS_FINITE_DOUBLE, is_finite_double);
 
-make_udf_function!(
-    is_infinite_impl::is_infinite_doubleFunc,
-    IS_INFINITE_DOUBLE,
-    is_infinite_double
-);
+make_udf_function!(is_infinite_impl::is_infinite_doubleFunc, IS_INFINITE_DOUBLE, is_infinite_double);
 
-make_udf_function!(
-    is_json_scalar_impl::is_json_scalar_jsonFunc,
-    IS_JSON_SCALAR_JSON,
-    is_json_scalar_json
-);
-make_udf_function!(
-    is_json_scalar_impl::is_json_scalar_varcharFunc,
-    IS_JSON_SCALAR_VARCHAR,
-    is_json_scalar_varchar
-);
+make_udf_function!(is_json_scalar_impl::is_json_scalar_jsonFunc, IS_JSON_SCALAR_JSON, is_json_scalar_json);
+make_udf_function!(is_json_scalar_impl::is_json_scalar_varcharFunc, IS_JSON_SCALAR_VARCHAR, is_json_scalar_varchar);
 
 make_udf_function!(is_nan_impl::is_nan_doubleFunc, IS_NAN_DOUBLE, is_nan_double);
 make_udf_function!(is_nan_impl::is_nan_realFunc, IS_NAN_REAL, is_nan_real);
 
-make_udf_function!(
-    jaccard_index_impl::jaccard_index_setdigest_setdigestFunc,
-    JACCARD_INDEX_SETDIGEST_SETDIGEST,
-    jaccard_index_setdigest_setdigest
-);
+make_udf_function!(jaccard_index_impl::jaccard_index_setdigest_setdigestFunc, JACCARD_INDEX_SETDIGEST_SETDIGEST, jaccard_index_setdigest_setdigest);
 
-make_udf_function!(
-    json_array_contains_impl::json_array_contains_json_bigintFunc,
-    JSON_ARRAY_CONTAINS_JSON_BIGINT,
-    json_array_contains_json_bigint
-);
-make_udf_function!(
-    json_array_contains_impl::json_array_contains_json_booleanFunc,
-    JSON_ARRAY_CONTAINS_JSON_BOOLEAN,
-    json_array_contains_json_boolean
-);
-make_udf_function!(
-    json_array_contains_impl::json_array_contains_json_doubleFunc,
-    JSON_ARRAY_CONTAINS_JSON_DOUBLE,
-    json_array_contains_json_double
-);
-make_udf_function!(
-    json_array_contains_impl::json_array_contains_json_varcharFunc,
-    JSON_ARRAY_CONTAINS_JSON_VARCHAR,
-    json_array_contains_json_varchar
-);
-make_udf_function!(
-    json_array_contains_impl::json_array_contains_varchar_bigintFunc,
-    JSON_ARRAY_CONTAINS_VARCHAR_BIGINT,
-    json_array_contains_varchar_bigint
-);
-make_udf_function!(
-    json_array_contains_impl::json_array_contains_varchar_booleanFunc,
-    JSON_ARRAY_CONTAINS_VARCHAR_BOOLEAN,
-    json_array_contains_varchar_boolean
-);
-make_udf_function!(
-    json_array_contains_impl::json_array_contains_varchar_doubleFunc,
-    JSON_ARRAY_CONTAINS_VARCHAR_DOUBLE,
-    json_array_contains_varchar_double
-);
-make_udf_function!(
-    json_array_contains_impl::json_array_contains_varchar_varcharFunc,
-    JSON_ARRAY_CONTAINS_VARCHAR_VARCHAR,
-    json_array_contains_varchar_varchar
-);
+make_udf_function!(json_array_contains_impl::json_array_contains_json_bigintFunc, JSON_ARRAY_CONTAINS_JSON_BIGINT, json_array_contains_json_bigint);
+make_udf_function!(json_array_contains_impl::json_array_contains_json_booleanFunc, JSON_ARRAY_CONTAINS_JSON_BOOLEAN, json_array_contains_json_boolean);
+make_udf_function!(json_array_contains_impl::json_array_contains_json_doubleFunc, JSON_ARRAY_CONTAINS_JSON_DOUBLE, json_array_contains_json_double);
+make_udf_function!(json_array_contains_impl::json_array_contains_json_varcharFunc, JSON_ARRAY_CONTAINS_JSON_VARCHAR, json_array_contains_json_varchar);
+make_udf_function!(json_array_contains_impl::json_array_contains_varchar_bigintFunc, JSON_ARRAY_CONTAINS_VARCHAR_BIGINT, json_array_contains_varchar_bigint);
+make_udf_function!(json_array_contains_impl::json_array_contains_varchar_booleanFunc, JSON_ARRAY_CONTAINS_VARCHAR_BOOLEAN, json_array_contains_varchar_boolean);
+make_udf_function!(json_array_contains_impl::json_array_contains_varchar_doubleFunc, JSON_ARRAY_CONTAINS_VARCHAR_DOUBLE, json_array_contains_varchar_double);
+make_udf_function!(json_array_contains_impl::json_array_contains_varchar_varcharFunc, JSON_ARRAY_CONTAINS_VARCHAR_VARCHAR, json_array_contains_varchar_varchar);
 
-make_udf_function!(
-    json_array_get_impl::json_array_get_json_bigintFunc,
-    JSON_ARRAY_GET_JSON_BIGINT,
-    json_array_get_json_bigint
-);
-make_udf_function!(
-    json_array_get_impl::json_array_get_varchar_bigintFunc,
-    JSON_ARRAY_GET_VARCHAR_BIGINT,
-    json_array_get_varchar_bigint
-);
+make_udf_function!(json_array_get_impl::json_array_get_json_bigintFunc, JSON_ARRAY_GET_JSON_BIGINT, json_array_get_json_bigint);
+make_udf_function!(json_array_get_impl::json_array_get_varchar_bigintFunc, JSON_ARRAY_GET_VARCHAR_BIGINT, json_array_get_varchar_bigint);
 
-make_udf_function!(
-    json_array_length_impl::json_array_length_jsonFunc,
-    JSON_ARRAY_LENGTH_JSON,
-    json_array_length_json
-);
-make_udf_function!(
-    json_array_length_impl::json_array_length_varcharFunc,
-    JSON_ARRAY_LENGTH_VARCHAR,
-    json_array_length_varchar
-);
+make_udf_function!(json_array_length_impl::json_array_length_jsonFunc, JSON_ARRAY_LENGTH_JSON, json_array_length_json);
+make_udf_function!(json_array_length_impl::json_array_length_varcharFunc, JSON_ARRAY_LENGTH_VARCHAR, json_array_length_varchar);
 
-make_udf_function!(
-    json_extract_impl::json_extract_json_jsonpathFunc,
-    JSON_EXTRACT_JSON_JSONPATH,
-    json_extract_json_jsonpath
-);
-make_udf_function!(
-    json_extract_impl::json_extract_varchar_jsonpathFunc,
-    JSON_EXTRACT_VARCHAR_JSONPATH,
-    json_extract_varchar_jsonpath
-);
+make_udf_function!(json_extract_impl::json_extract_json_jsonpathFunc, JSON_EXTRACT_JSON_JSONPATH, json_extract_json_jsonpath);
+make_udf_function!(json_extract_impl::json_extract_varchar_jsonpathFunc, JSON_EXTRACT_VARCHAR_JSONPATH, json_extract_varchar_jsonpath);
 
-make_udf_function!(
-    json_extract_scalar_impl::json_extract_scalar_json_jsonpathFunc,
-    JSON_EXTRACT_SCALAR_JSON_JSONPATH,
-    json_extract_scalar_json_jsonpath
-);
-make_udf_function!(
-    json_extract_scalar_impl::json_extract_scalar_varchar_jsonpathFunc,
-    JSON_EXTRACT_SCALAR_VARCHAR_JSONPATH,
-    json_extract_scalar_varchar_jsonpath
-);
+make_udf_function!(json_extract_scalar_impl::json_extract_scalar_json_jsonpathFunc, JSON_EXTRACT_SCALAR_JSON_JSONPATH, json_extract_scalar_json_jsonpath);
+make_udf_function!(json_extract_scalar_impl::json_extract_scalar_varchar_jsonpathFunc, JSON_EXTRACT_SCALAR_VARCHAR_JSONPATH, json_extract_scalar_varchar_jsonpath);
 
-make_udf_function!(
-    json_format_impl::json_format_jsonFunc,
-    JSON_FORMAT_JSON,
-    json_format_json
-);
+make_udf_function!(json_format_impl::json_format_jsonFunc, JSON_FORMAT_JSON, json_format_json);
 
-make_udf_function!(
-    json_parse_impl::json_parse_varcharFunc,
-    JSON_PARSE_VARCHAR,
-    json_parse_varchar
-);
+make_udf_function!(json_parse_impl::json_parse_varcharFunc, JSON_PARSE_VARCHAR, json_parse_varchar);
 
-make_udf_function!(
-    json_size_impl::json_size_json_jsonpathFunc,
-    JSON_SIZE_JSON_JSONPATH,
-    json_size_json_jsonpath
-);
-make_udf_function!(
-    json_size_impl::json_size_varchar_jsonpathFunc,
-    JSON_SIZE_VARCHAR_JSONPATH,
-    json_size_varchar_jsonpath
-);
+make_udf_function!(json_size_impl::json_size_json_jsonpathFunc, JSON_SIZE_JSON_JSONPATH, json_size_json_jsonpath);
+make_udf_function!(json_size_impl::json_size_varchar_jsonpathFunc, JSON_SIZE_VARCHAR_JSONPATH, json_size_varchar_jsonpath);
 
-make_udf_function!(
-    last_day_of_month_impl::last_day_of_month_dateFunc,
-    LAST_DAY_OF_MONTH_DATE,
-    last_day_of_month_date
-);
-make_udf_function!(
-    last_day_of_month_impl::last_day_of_month_timestamp_pFunc,
-    LAST_DAY_OF_MONTH_TIMESTAMP_P,
-    last_day_of_month_timestamp_p
-);
+make_udf_function!(last_day_of_month_impl::last_day_of_month_dateFunc, LAST_DAY_OF_MONTH_DATE, last_day_of_month_date);
+make_udf_function!(last_day_of_month_impl::last_day_of_month_timestamp_pFunc, LAST_DAY_OF_MONTH_TIMESTAMP_P, last_day_of_month_timestamp_p);
 
 make_udf_function!(least_impl::least_3Func, LEAST_3, least_3);
 
-make_udf_function!(
-    length_impl::length_varcharFunc,
-    LENGTH_VARCHAR,
-    length_varchar
-);
-make_udf_function!(
-    length_impl::length_varbinaryFunc,
-    LENGTH_VARBINARY,
-    length_varbinary
-);
-make_udf_function!(
-    length_impl::length_array_1Func,
-    LENGTH_ARRAY_1,
-    length_array_1
-);
+make_udf_function!(length_impl::length_varcharFunc, LENGTH_VARCHAR, length_varchar);
+make_udf_function!(length_impl::length_varbinaryFunc, LENGTH_VARBINARY, length_varbinary);
 
-make_udf_function!(
-    levenshtein_distance_impl::levenshtein_distance_varchar_varcharFunc,
-    LEVENSHTEIN_DISTANCE_VARCHAR_VARCHAR,
-    levenshtein_distance_varchar_varchar
-);
+make_udf_function!(levenshtein_distance_impl::levenshtein_distance_varchar_varcharFunc, LEVENSHTEIN_DISTANCE_VARCHAR_VARCHAR, levenshtein_distance_varchar_varchar);
 
-make_udf_function!(
-    line_interpolate_point_impl::line_interpolate_point_geometry_doubleFunc,
-    LINE_INTERPOLATE_POINT_GEOMETRY_DOUBLE,
-    line_interpolate_point_geometry_double
-);
+make_udf_function!(line_interpolate_point_impl::line_interpolate_point_geometry_doubleFunc, LINE_INTERPOLATE_POINT_GEOMETRY_DOUBLE, line_interpolate_point_geometry_double);
 
-make_udf_function!(
-    line_interpolate_points_impl::line_interpolate_points_geometry_doubleFunc,
-    LINE_INTERPOLATE_POINTS_GEOMETRY_DOUBLE,
-    line_interpolate_points_geometry_double
-);
+make_udf_function!(line_interpolate_points_impl::line_interpolate_points_geometry_doubleFunc, LINE_INTERPOLATE_POINTS_GEOMETRY_DOUBLE, line_interpolate_points_geometry_double);
 
-make_udf_function!(
-    line_locate_point_impl::line_locate_point_geometry_geometryFunc,
-    LINE_LOCATE_POINT_GEOMETRY_GEOMETRY,
-    line_locate_point_geometry_geometry
-);
+make_udf_function!(line_locate_point_impl::line_locate_point_geometry_geometryFunc, LINE_LOCATE_POINT_GEOMETRY_GEOMETRY, line_locate_point_geometry_geometry);
 
 make_udf_function!(ln_impl::ln_doubleFunc, LN_DOUBLE, ln_double);
 
 make_udf_function!(localtime_impl::localtimeFunc, LOCALTIME, localtime);
 
-make_udf_function!(
-    localtimestamp_impl::localtimestampFunc,
-    LOCALTIMESTAMP,
-    localtimestamp
-);
-make_udf_function!(
-    localtimestamp_impl::localtimestamp_bigint_0Func,
-    LOCALTIMESTAMP_BIGINT_0,
-    localtimestamp_bigint_0
-);
-make_udf_function!(
-    localtimestamp_impl::localtimestamp_bigint_3Func,
-    LOCALTIMESTAMP_BIGINT_3,
-    localtimestamp_bigint_3
-);
-make_udf_function!(
-    localtimestamp_impl::localtimestamp_bigint_6Func,
-    LOCALTIMESTAMP_BIGINT_6,
-    localtimestamp_bigint_6
-);
-make_udf_function!(
-    localtimestamp_impl::localtimestamp_bigint_9Func,
-    LOCALTIMESTAMP_BIGINT_9,
-    localtimestamp_bigint_9
-);
+make_udf_function!(localtimestamp_impl::localtimestampFunc, LOCALTIMESTAMP, localtimestamp);
+make_udf_function!(localtimestamp_impl::localtimestamp_bigint_0Func, LOCALTIMESTAMP_BIGINT_0, localtimestamp_bigint_0);
+make_udf_function!(localtimestamp_impl::localtimestamp_bigint_3Func, LOCALTIMESTAMP_BIGINT_3, localtimestamp_bigint_3);
+make_udf_function!(localtimestamp_impl::localtimestamp_bigint_6Func, LOCALTIMESTAMP_BIGINT_6, localtimestamp_bigint_6);
+make_udf_function!(localtimestamp_impl::localtimestamp_bigint_9Func, LOCALTIMESTAMP_BIGINT_9, localtimestamp_bigint_9);
 
-make_udf_function!(
-    log_impl::log_double_doubleFunc,
-    LOG_DOUBLE_DOUBLE,
-    log_double_double
-);
+make_udf_function!(log_impl::log_double_doubleFunc, LOG_DOUBLE_DOUBLE, log_double_double);
 
 make_udf_function!(log10_impl::log10_doubleFunc, LOG10_DOUBLE, log10_double);
 
@@ -1674,1319 +786,435 @@ make_udf_function!(log2_impl::log2_doubleFunc, LOG2_DOUBLE, log2_double);
 
 make_udf_function!(lower_impl::lower_varcharFunc, LOWER_VARCHAR, lower_varchar);
 
-make_udf_function!(
-    lpad_impl::lpad_varbinary_bigint_varbinaryFunc,
-    LPAD_VARBINARY_BIGINT_VARBINARY,
-    lpad_varbinary_bigint_varbinary
-);
-make_udf_function!(
-    lpad_impl::lpad_varchar_bigint_varcharFunc,
-    LPAD_VARCHAR_BIGINT_VARCHAR,
-    lpad_varchar_bigint_varchar
-);
+make_udf_function!(lpad_impl::lpad_varbinary_bigint_varbinaryFunc, LPAD_VARBINARY_BIGINT_VARBINARY, lpad_varbinary_bigint_varbinary);
+make_udf_function!(lpad_impl::lpad_varchar_bigint_varcharFunc, LPAD_VARCHAR_BIGINT_VARCHAR, lpad_varchar_bigint_varchar);
 
 make_udf_function!(ltrim_impl::ltrim_varcharFunc, LTRIM_VARCHAR, ltrim_varchar);
-make_udf_function!(
-    ltrim_impl::ltrim_varchar_codepointsFunc,
-    LTRIM_VARCHAR_CODEPOINTS,
-    ltrim_varchar_codepoints
-);
+make_udf_function!(ltrim_impl::ltrim_varchar_codepointsFunc, LTRIM_VARCHAR_CODEPOINTS, ltrim_varchar_codepoints);
 
-make_udf_function!(
-    luhn_check_impl::luhn_check_varcharFunc,
-    LUHN_CHECK_VARCHAR,
-    luhn_check_varchar
-);
+make_udf_function!(luhn_check_impl::luhn_check_varcharFunc, LUHN_CHECK_VARCHAR, luhn_check_varchar);
 
-make_udf_function!(
-    map_impl::map_array_4_array_5Func,
-    MAP_ARRAY_4_ARRAY_5,
-    map_array_4_array_5
-);
+make_udf_function!(map_impl::map_array_4_array_5Func, MAP_ARRAY_4_ARRAY_5, map_array_4_array_5);
 make_udf_function!(map_impl::mapFunc, MAP, map);
 
-make_udf_function!(
-    map_concat_impl::map_concat_map_4_5Func,
-    MAP_CONCAT_MAP_4_5,
-    map_concat_map_4_5
-);
+make_udf_function!(map_concat_impl::map_concat_map_4_5Func, MAP_CONCAT_MAP_4_5, map_concat_map_4_5);
 
-make_udf_function!(
-    map_entries_impl::map_entries_map_4_5Func,
-    MAP_ENTRIES_MAP_4_5,
-    map_entries_map_4_5
-);
+make_udf_function!(map_entries_impl::map_entries_map_4_5Func, MAP_ENTRIES_MAP_4_5, map_entries_map_4_5);
 
-make_udf_function!(
-    map_filter_impl::map_filter_map_4_5_function_4_5_booleanFunc,
-    MAP_FILTER_MAP_4_5_FUNCTION_4_5_BOOLEAN,
-    map_filter_map_4_5_function_4_5_boolean
-);
+make_udf_function!(map_filter_impl::map_filter_map_4_5_function_4_5_booleanFunc, MAP_FILTER_MAP_4_5_FUNCTION_4_5_BOOLEAN, map_filter_map_4_5_function_4_5_boolean);
 
-make_udf_function!(
-    map_from_entries_impl::map_from_entries_array_row_c04_c15Func,
-    MAP_FROM_ENTRIES_ARRAY_ROW_C04_C15,
-    map_from_entries_array_row_c04_c15
-);
+make_udf_function!(map_from_entries_impl::map_from_entries_array_row_c04_c15Func, MAP_FROM_ENTRIES_ARRAY_ROW_C04_C15, map_from_entries_array_row_c04_c15);
 
-make_udf_function!(
-    map_keys_impl::map_keys_map_4_5Func,
-    MAP_KEYS_MAP_4_5,
-    map_keys_map_4_5
-);
+make_udf_function!(map_keys_impl::map_keys_map_4_5Func, MAP_KEYS_MAP_4_5, map_keys_map_4_5);
 
-make_udf_function!(
-    map_values_impl::map_values_map_4_5Func,
-    MAP_VALUES_MAP_4_5,
-    map_values_map_4_5
-);
+make_udf_function!(map_values_impl::map_values_map_4_5Func, MAP_VALUES_MAP_4_5, map_values_map_4_5);
 
-make_udf_function!(
-    map_zip_with_impl::map_zip_with_map_4_8_map_4_7_function_4_8_7_6Func,
-    MAP_ZIP_WITH_MAP_4_8_MAP_4_7_FUNCTION_4_8_7_6,
-    map_zip_with_map_4_8_map_4_7_function_4_8_7_6
-);
+make_udf_function!(map_zip_with_impl::map_zip_with_map_4_8_map_4_7_function_4_8_7_6Func, MAP_ZIP_WITH_MAP_4_8_MAP_4_7_FUNCTION_4_8_7_6, map_zip_with_map_4_8_map_4_7_function_4_8_7_6);
 
 make_udf_function!(md5_impl::md5_varbinaryFunc, MD5_VARBINARY, md5_varbinary);
 
-make_udf_function!(
-    millisecond_impl::millisecond_intervaldaytosecondFunc,
-    MILLISECOND_INTERVALDAYTOSECOND,
-    millisecond_intervaldaytosecond
-);
-make_udf_function!(
-    millisecond_impl::millisecond_time_pFunc,
-    MILLISECOND_TIME_P,
-    millisecond_time_p
-);
-make_udf_function!(
-    millisecond_impl::millisecond_timestamp_pFunc,
-    MILLISECOND_TIMESTAMP_P,
-    millisecond_timestamp_p
-);
+make_udf_function!(millisecond_impl::millisecond_intervaldaytosecondFunc, MILLISECOND_INTERVALDAYTOSECOND, millisecond_intervaldaytosecond);
+make_udf_function!(millisecond_impl::millisecond_time_pFunc, MILLISECOND_TIME_P, millisecond_time_p);
+make_udf_function!(millisecond_impl::millisecond_timestamp_pFunc, MILLISECOND_TIMESTAMP_P, millisecond_timestamp_p);
 
-make_udf_function!(
-    minute_impl::minute_intervaldaytosecondFunc,
-    MINUTE_INTERVALDAYTOSECOND,
-    minute_intervaldaytosecond
-);
+make_udf_function!(minute_impl::minute_intervaldaytosecondFunc, MINUTE_INTERVALDAYTOSECOND, minute_intervaldaytosecond);
 make_udf_function!(minute_impl::minute_time_pFunc, MINUTE_TIME_P, minute_time_p);
-make_udf_function!(
-    minute_impl::minute_timestamp_pFunc,
-    MINUTE_TIMESTAMP_P,
-    minute_timestamp_p
-);
+make_udf_function!(minute_impl::minute_timestamp_pFunc, MINUTE_TIMESTAMP_P, minute_timestamp_p);
 
-make_udf_function!(
-    mod_impl::mod_bigint_bigintFunc,
-    MOD_BIGINT_BIGINT,
-    mod_bigint_bigint
-);
-make_udf_function!(
-    mod_impl::mod_decimal_a_precision_a_scale_decimal_b_precision_b_scaleFunc,
-    MOD_DECIMAL_A_PRECISION_A_SCALE_DECIMAL_B_PRECISION_B_SCALE,
-    mod_decimal_a_precision_a_scale_decimal_b_precision_b_scale
-);
-make_udf_function!(
-    mod_impl::mod_double_doubleFunc,
-    MOD_DOUBLE_DOUBLE,
-    mod_double_double
-);
-make_udf_function!(
-    mod_impl::mod_integer_integerFunc,
-    MOD_INTEGER_INTEGER,
-    mod_integer_integer
-);
+make_udf_function!(mod_impl::mod_bigint_bigintFunc, MOD_BIGINT_BIGINT, mod_bigint_bigint);
+make_udf_function!(mod_impl::mod_decimal_a_precision_a_scale_decimal_b_precision_b_scaleFunc, MOD_DECIMAL_A_PRECISION_A_SCALE_DECIMAL_B_PRECISION_B_SCALE, mod_decimal_a_precision_a_scale_decimal_b_precision_b_scale);
+make_udf_function!(mod_impl::mod_double_doubleFunc, MOD_DOUBLE_DOUBLE, mod_double_double);
+make_udf_function!(mod_impl::mod_integer_integerFunc, MOD_INTEGER_INTEGER, mod_integer_integer);
 make_udf_function!(mod_impl::mod_real_realFunc, MOD_REAL_REAL, mod_real_real);
-make_udf_function!(
-    mod_impl::mod_smallint_smallintFunc,
-    MOD_SMALLINT_SMALLINT,
-    mod_smallint_smallint
-);
-make_udf_function!(
-    mod_impl::mod_tinyint_tinyintFunc,
-    MOD_TINYINT_TINYINT,
-    mod_tinyint_tinyint
-);
+make_udf_function!(mod_impl::mod_smallint_smallintFunc, MOD_SMALLINT_SMALLINT, mod_smallint_smallint);
+make_udf_function!(mod_impl::mod_tinyint_tinyintFunc, MOD_TINYINT_TINYINT, mod_tinyint_tinyint);
 
 make_udf_function!(month_impl::month_dateFunc, MONTH_DATE, month_date);
-make_udf_function!(
-    month_impl::month_intervalyeartomonthFunc,
-    MONTH_INTERVALYEARTOMONTH,
-    month_intervalyeartomonth
-);
-make_udf_function!(
-    month_impl::month_timestamp_pFunc,
-    MONTH_TIMESTAMP_P,
-    month_timestamp_p
-);
+make_udf_function!(month_impl::month_intervalyeartomonthFunc, MONTH_INTERVALYEARTOMONTH, month_intervalyeartomonth);
+make_udf_function!(month_impl::month_timestamp_pFunc, MONTH_TIMESTAMP_P, month_timestamp_p);
 
-make_udf_function!(
-    multimap_from_entries_impl::multimap_from_entries_array_row_c04_c15Func,
-    MULTIMAP_FROM_ENTRIES_ARRAY_ROW_C04_C15,
-    multimap_from_entries_array_row_c04_c15
-);
+make_udf_function!(multimap_from_entries_impl::multimap_from_entries_array_row_c04_c15Func, MULTIMAP_FROM_ENTRIES_ARRAY_ROW_C04_C15, multimap_from_entries_array_row_c04_c15);
 
-make_udf_function!(
-    murmur3_impl::murmur3_varbinaryFunc,
-    MURMUR3_VARBINARY,
-    murmur3_varbinary
-);
+make_udf_function!(murmur3_impl::murmur3_varbinaryFunc, MURMUR3_VARBINARY, murmur3_varbinary);
 
 make_udf_function!(nan_impl::nanFunc, NAN, nan);
 
-make_udf_function!(
-    ngrams_impl::ngrams_array_1_bigintFunc,
-    NGRAMS_ARRAY_1_BIGINT,
-    ngrams_array_1_bigint
-);
+make_udf_function!(ngrams_impl::ngrams_array_1_bigintFunc, NGRAMS_ARRAY_1_BIGINT, ngrams_array_1_bigint);
 
-make_udf_function!(
-    none_match_impl::none_match_array_1_function_1_booleanFunc,
-    NONE_MATCH_ARRAY_1_FUNCTION_1_BOOLEAN,
-    none_match_array_1_function_1_boolean
-);
+make_udf_function!(none_match_impl::none_match_array_1_function_1_booleanFunc, NONE_MATCH_ARRAY_1_FUNCTION_1_BOOLEAN, none_match_array_1_function_1_boolean);
 
-make_udf_function!(
-    normal_cdf_impl::normal_cdf_double_double_doubleFunc,
-    NORMAL_CDF_DOUBLE_DOUBLE_DOUBLE,
-    normal_cdf_double_double_double
-);
+make_udf_function!(normal_cdf_impl::normal_cdf_double_double_doubleFunc, NORMAL_CDF_DOUBLE_DOUBLE_DOUBLE, normal_cdf_double_double_double);
 
-make_udf_function!(
-    normalize_impl::normalize_varchar_varcharFunc,
-    NORMALIZE_VARCHAR_VARCHAR,
-    normalize_varchar_varchar
-);
+make_udf_function!(normalize_impl::normalize_varchar_varcharFunc, NORMALIZE_VARCHAR_VARCHAR, normalize_varchar_varchar);
 
 make_udf_function!(now_impl::nowFunc, NOW, now);
 
 make_udf_function!(nullif_impl::nullif_1_1Func, NULLIF_1_1, nullif_1_1);
 
 make_udf_function!(objectid_impl::objectidFunc, OBJECTID, objectid);
-make_udf_function!(
-    objectid_impl::objectid_varcharFunc,
-    OBJECTID_VARCHAR,
-    objectid_varchar
-);
+make_udf_function!(objectid_impl::objectid_varcharFunc, OBJECTID_VARCHAR, objectid_varchar);
 
-make_udf_function!(
-    objectid_timestamp_impl::objectid_timestamp_objectidFunc,
-    OBJECTID_TIMESTAMP_OBJECTID,
-    objectid_timestamp_objectid
-);
+make_udf_function!(objectid_timestamp_impl::objectid_timestamp_objectidFunc, OBJECTID_TIMESTAMP_OBJECTID, objectid_timestamp_objectid);
 
-make_udf_function!(
-    parse_data_size_impl::parse_data_size_varcharFunc,
-    PARSE_DATA_SIZE_VARCHAR,
-    parse_data_size_varchar
-);
+make_udf_function!(parse_data_size_impl::parse_data_size_varcharFunc, PARSE_DATA_SIZE_VARCHAR, parse_data_size_varchar);
 
-make_udf_function!(
-    parse_datetime_impl::parse_datetime_varchar_varcharFunc,
-    PARSE_DATETIME_VARCHAR_VARCHAR,
-    parse_datetime_varchar_varchar
-);
+make_udf_function!(parse_datetime_impl::parse_datetime_varchar_varcharFunc, PARSE_DATETIME_VARCHAR_VARCHAR, parse_datetime_varchar_varchar);
 
-make_udf_function!(
-    parse_duration_impl::parse_duration_varcharFunc,
-    PARSE_DURATION_VARCHAR,
-    parse_duration_varchar
-);
+make_udf_function!(parse_duration_impl::parse_duration_varcharFunc, PARSE_DURATION_VARCHAR, parse_duration_varchar);
 
-make_udf_function!(
-    parse_presto_data_size_impl::parse_presto_data_size_varcharFunc,
-    PARSE_PRETO_DATA_SIZE_VARCHAR,
-    parse_presto_data_size_varchar
-);
+make_udf_function!(parse_presto_data_size_impl::parse_presto_data_size_varcharFunc, PARSE_PRESTO_DATA_SIZE_VARCHAR, parse_presto_data_size_varchar);
 
 make_udf_function!(pi_impl::piFunc, PI, pi);
 
-make_udf_function!(
-    pow_impl::pow_double_doubleFunc,
-    POW_DOUBLE_DOUBLE,
-    pow_double_double
-);
+make_udf_function!(pow_impl::pow_double_doubleFunc, POW_DOUBLE_DOUBLE, pow_double_double);
 
-make_udf_function!(
-    power_impl::power_double_doubleFunc,
-    POWER_DOUBLE_DOUBLE,
-    power_double_double
-);
+make_udf_function!(power_impl::power_double_doubleFunc, POWER_DOUBLE_DOUBLE, power_double_double);
 
-make_udf_function!(
-    quantile_at_value_impl::quantile_at_value_qdigest_bigintFunc,
-    QUANTILE_AT_VALUE_QDIGEST_BIGINT,
-    quantile_at_value_qdigest_bigint
-);
-make_udf_function!(
-    quantile_at_value_impl::quantile_at_value_qdigest_doubleFunc,
-    QUANTILE_AT_VALUE_QDIGEST_DOUBLE,
-    quantile_at_value_qdigest_double
-);
-make_udf_function!(
-    quantile_at_value_impl::quantile_at_value_qdigest_realFunc,
-    QUANTILE_AT_VALUE_QDIGEST_REAL,
-    quantile_at_value_qdigest_real
-);
+make_udf_function!(quantile_at_value_impl::quantile_at_value_qdigest_bigintFunc, QUANTILE_AT_VALUE_QDIGEST_BIGINT, quantile_at_value_qdigest_bigint);
+make_udf_function!(quantile_at_value_impl::quantile_at_value_qdigest_doubleFunc, QUANTILE_AT_VALUE_QDIGEST_DOUBLE, quantile_at_value_qdigest_double);
+make_udf_function!(quantile_at_value_impl::quantile_at_value_qdigest_realFunc, QUANTILE_AT_VALUE_QDIGEST_REAL, quantile_at_value_qdigest_real);
 
 make_udf_function!(quarter_impl::quarter_dateFunc, QUARTER_DATE, quarter_date);
-make_udf_function!(
-    quarter_impl::quarter_timestamp_pFunc,
-    QUARTER_TIMESTAMP_P,
-    quarter_timestamp_p
-);
+make_udf_function!(quarter_impl::quarter_timestamp_pFunc, QUARTER_TIMESTAMP_P, quarter_timestamp_p);
 
-make_udf_function!(
-    radians_impl::radians_doubleFunc,
-    RADIANS_DOUBLE,
-    radians_double
-);
+make_udf_function!(radians_impl::radians_doubleFunc, RADIANS_DOUBLE, radians_double);
 
 make_udf_function!(rand_impl::rand_bigintFunc, RAND_BIGINT, rand_bigint);
-make_udf_function!(
-    rand_impl::rand_bigint_bigintFunc,
-    RAND_BIGINT_BIGINT,
-    rand_bigint_bigint
-);
+make_udf_function!(rand_impl::rand_bigint_bigintFunc, RAND_BIGINT_BIGINT, rand_bigint_bigint);
 make_udf_function!(rand_impl::randFunc, RAND, rand);
 make_udf_function!(rand_impl::rand_integerFunc, RAND_INTEGER, rand_integer);
-make_udf_function!(
-    rand_impl::rand_integer_integerFunc,
-    RAND_INTEGER_INTEGER,
-    rand_integer_integer
-);
+make_udf_function!(rand_impl::rand_integer_integerFunc, RAND_INTEGER_INTEGER, rand_integer_integer);
 make_udf_function!(rand_impl::rand_smallintFunc, RAND_SMALLINT, rand_smallint);
-make_udf_function!(
-    rand_impl::rand_smallint_smallintFunc,
-    RAND_SMALLINT_SMALLINT,
-    rand_smallint_smallint
-);
+make_udf_function!(rand_impl::rand_smallint_smallintFunc, RAND_SMALLINT_SMALLINT, rand_smallint_smallint);
 make_udf_function!(rand_impl::rand_tinyintFunc, RAND_TINYINT, rand_tinyint);
-make_udf_function!(
-    rand_impl::rand_tinyint_tinyintFunc,
-    RAND_TINYINT_TINYINT,
-    rand_tinyint_tinyint
-);
+make_udf_function!(rand_impl::rand_tinyint_tinyintFunc, RAND_TINYINT_TINYINT, rand_tinyint_tinyint);
 
 make_udf_function!(random_impl::random_bigintFunc, RANDOM_BIGINT, random_bigint);
-make_udf_function!(
-    random_impl::random_bigint_bigintFunc,
-    RANDOM_BIGINT_BIGINT,
-    random_bigint_bigint
-);
+make_udf_function!(random_impl::random_bigint_bigintFunc, RANDOM_BIGINT_BIGINT, random_bigint_bigint);
 make_udf_function!(random_impl::randomFunc, RANDOM, random);
-make_udf_function!(
-    random_impl::random_integerFunc,
-    RANDOM_INTEGER,
-    random_integer
-);
-make_udf_function!(
-    random_impl::random_integer_integerFunc,
-    RANDOM_INTEGER_INTEGER,
-    random_integer_integer
-);
-make_udf_function!(
-    random_impl::random_smallintFunc,
-    RANDOM_SMALLINT,
-    random_smallint
-);
-make_udf_function!(
-    random_impl::random_smallint_smallintFunc,
-    RANDOM_SMALLINT_SMALLINT,
-    random_smallint_smallint
-);
-make_udf_function!(
-    random_impl::random_tinyintFunc,
-    RANDOM_TINYINT,
-    random_tinyint
-);
-make_udf_function!(
-    random_impl::random_tinyint_tinyintFunc,
-    RANDOM_TINYINT_TINYINT,
-    random_tinyint_tinyint
-);
+make_udf_function!(random_impl::random_integerFunc, RANDOM_INTEGER, random_integer);
+make_udf_function!(random_impl::random_integer_integerFunc, RANDOM_INTEGER_INTEGER, random_integer_integer);
+make_udf_function!(random_impl::random_smallintFunc, RANDOM_SMALLINT, random_smallint);
+make_udf_function!(random_impl::random_smallint_smallintFunc, RANDOM_SMALLINT_SMALLINT, random_smallint_smallint);
+make_udf_function!(random_impl::random_tinyintFunc, RANDOM_TINYINT, random_tinyint);
+make_udf_function!(random_impl::random_tinyint_tinyintFunc, RANDOM_TINYINT_TINYINT, random_tinyint_tinyint);
 
-make_udf_function!(
-    reduce_impl::reduce_array_1_10_function_10_1_10_function_10_9Func,
-    REDUCE_ARRAY_1_10_FUNCTION_10_1_10_FUNCTION_10_9,
-    reduce_array_1_10_function_10_1_10_function_10_9
-);
+make_udf_function!(reduce_impl::reduce_array_1_10_function_10_1_10_function_10_9Func, REDUCE_ARRAY_1_10_FUNCTION_10_1_10_FUNCTION_10_9, reduce_array_1_10_function_10_1_10_function_10_9);
 
-make_udf_function!(
-    regexp_count_impl::regexp_count_varchar_joniregexpFunc,
-    REGEXP_COUNT_VARCHAR_JONIREGEXP,
-    regexp_count_varchar_joniregexp
-);
+make_udf_function!(regexp_count_impl::regexp_count_varchar_joniregexpFunc, REGEXP_COUNT_VARCHAR_JONIREGEXP, regexp_count_varchar_joniregexp);
 
-make_udf_function!(
-    regexp_extract_impl::regexp_extract_varchar_joniregexpFunc,
-    REGEXP_EXTRACT_VARCHAR_JONIREGEXP,
-    regexp_extract_varchar_joniregexp
-);
-make_udf_function!(
-    regexp_extract_impl::regexp_extract_varchar_joniregexp_bigintFunc,
-    REGEXP_EXTRACT_VARCHAR_JONIREGEXP_BIGINT,
-    regexp_extract_varchar_joniregexp_bigint
-);
+make_udf_function!(regexp_extract_impl::regexp_extract_varchar_joniregexpFunc, REGEXP_EXTRACT_VARCHAR_JONIREGEXP, regexp_extract_varchar_joniregexp);
+make_udf_function!(regexp_extract_impl::regexp_extract_varchar_joniregexp_bigintFunc, REGEXP_EXTRACT_VARCHAR_JONIREGEXP_BIGINT, regexp_extract_varchar_joniregexp_bigint);
 
-make_udf_function!(
-    regexp_extract_all_impl::regexp_extract_all_varchar_joniregexpFunc,
-    REGEXP_EXTRACT_ALL_VARCHAR_JONIREGEXP,
-    regexp_extract_all_varchar_joniregexp
-);
-make_udf_function!(
-    regexp_extract_all_impl::regexp_extract_all_varchar_joniregexp_bigintFunc,
-    REGEXP_EXTRACT_ALL_VARCHAR_JONIREGEXP_BIGINT,
-    regexp_extract_all_varchar_joniregexp_bigint
-);
+make_udf_function!(regexp_extract_all_impl::regexp_extract_all_varchar_joniregexpFunc, REGEXP_EXTRACT_ALL_VARCHAR_JONIREGEXP, regexp_extract_all_varchar_joniregexp);
+make_udf_function!(regexp_extract_all_impl::regexp_extract_all_varchar_joniregexp_bigintFunc, REGEXP_EXTRACT_ALL_VARCHAR_JONIREGEXP_BIGINT, regexp_extract_all_varchar_joniregexp_bigint);
 
-make_udf_function!(
-    regexp_like_impl::regexp_like_varchar_joniregexpFunc,
-    REGEXP_LIKE_VARCHAR_JONIREGEXP,
-    regexp_like_varchar_joniregexp
-);
+make_udf_function!(regexp_like_impl::regexp_like_varchar_joniregexpFunc, REGEXP_LIKE_VARCHAR_JONIREGEXP, regexp_like_varchar_joniregexp);
 
-make_udf_function!(
-    regexp_position_impl::regexp_position_varchar_joniregexpFunc,
-    REGEXP_POSITION_VARCHAR_JONIREGEXP,
-    regexp_position_varchar_joniregexp
-);
-make_udf_function!(
-    regexp_position_impl::regexp_position_varchar_joniregexp_bigintFunc,
-    REGEXP_POSITION_VARCHAR_JONIREGEXP_BIGINT,
-    regexp_position_varchar_joniregexp_bigint
-);
-make_udf_function!(
-    regexp_position_impl::regexp_position_varchar_joniregexp_bigint_bigintFunc,
-    REGEXP_POSITION_VARCHAR_JONIREGEXP_BIGINT_BIGINT,
-    regexp_position_varchar_joniregexp_bigint_bigint
-);
+make_udf_function!(regexp_position_impl::regexp_position_varchar_joniregexpFunc, REGEXP_POSITION_VARCHAR_JONIREGEXP, regexp_position_varchar_joniregexp);
+make_udf_function!(regexp_position_impl::regexp_position_varchar_joniregexp_bigintFunc, REGEXP_POSITION_VARCHAR_JONIREGEXP_BIGINT, regexp_position_varchar_joniregexp_bigint);
+make_udf_function!(regexp_position_impl::regexp_position_varchar_joniregexp_bigint_bigintFunc, REGEXP_POSITION_VARCHAR_JONIREGEXP_BIGINT_BIGINT, regexp_position_varchar_joniregexp_bigint_bigint);
 
-make_udf_function!(
-    regexp_replace_impl::regexp_replace_varchar_joniregexp_function_array_varchar_varcharFunc,
-    REGEXP_REPLACE_VARCHAR_JONIREGEXP_FUNCTION_ARRAY_VARCHAR_VARCHAR,
-    regexp_replace_varchar_joniregexp_function_array_varchar_varchar
-);
-make_udf_function!(
-    regexp_replace_impl::regexp_replace_varchar_joniregexpFunc,
-    REGEXP_REPLACE_VARCHAR_JONIREGEXP,
-    regexp_replace_varchar_joniregexp
-);
-make_udf_function!(
-    regexp_replace_impl::regexp_replace_varchar_joniregexp_varcharFunc,
-    REGEXP_REPLACE_VARCHAR_JONIREGEXP_VARCHAR,
-    regexp_replace_varchar_joniregexp_varchar
-);
+make_udf_function!(regexp_replace_impl::regexp_replace_varchar_joniregexp_function_array_varchar_varcharFunc, REGEXP_REPLACE_VARCHAR_JONIREGEXP_FUNCTION_ARRAY_VARCHAR_VARCHAR, regexp_replace_varchar_joniregexp_function_array_varchar_varchar);
+make_udf_function!(regexp_replace_impl::regexp_replace_varchar_joniregexpFunc, REGEXP_REPLACE_VARCHAR_JONIREGEXP, regexp_replace_varchar_joniregexp);
+make_udf_function!(regexp_replace_impl::regexp_replace_varchar_joniregexp_varcharFunc, REGEXP_REPLACE_VARCHAR_JONIREGEXP_VARCHAR, regexp_replace_varchar_joniregexp_varchar);
 
-make_udf_function!(
-    regexp_split_impl::regexp_split_varchar_joniregexpFunc,
-    REGEXP_SPLIT_VARCHAR_JONIREGEXP,
-    regexp_split_varchar_joniregexp
-);
+make_udf_function!(regexp_split_impl::regexp_split_varchar_joniregexpFunc, REGEXP_SPLIT_VARCHAR_JONIREGEXP, regexp_split_varchar_joniregexp);
 
-make_udf_function!(
-    regress_impl::regress_map_bigint_double_regressorFunc,
-    REGRESS_MAP_BIGINT_DOUBLE_REGRESSOR,
-    regress_map_bigint_double_regressor
-);
+make_udf_function!(regress_impl::regress_map_bigint_double_regressorFunc, REGRESS_MAP_BIGINT_DOUBLE_REGRESSOR, regress_map_bigint_double_regressor);
 
-make_udf_function!(
-    render_impl::render_booleanFunc,
-    RENDER_BOOLEAN,
-    render_boolean
-);
-make_udf_function!(
-    render_impl::render_bigint_colorFunc,
-    RENDER_BIGINT_COLOR,
-    render_bigint_color
-);
-make_udf_function!(
-    render_impl::render_double_colorFunc,
-    RENDER_DOUBLE_COLOR,
-    render_double_color
-);
-make_udf_function!(
-    render_impl::render_varchar_colorFunc,
-    RENDER_VARCHAR_COLOR,
-    render_varchar_color
-);
+make_udf_function!(render_impl::render_booleanFunc, RENDER_BOOLEAN, render_boolean);
+make_udf_function!(render_impl::render_bigint_colorFunc, RENDER_BIGINT_COLOR, render_bigint_color);
+make_udf_function!(render_impl::render_double_colorFunc, RENDER_DOUBLE_COLOR, render_double_color);
+make_udf_function!(render_impl::render_varchar_colorFunc, RENDER_VARCHAR_COLOR, render_varchar_color);
 
-make_udf_function!(
-    repeat_impl::repeat_1_bigintFunc,
-    REPEAT_1_BIGINT,
-    repeat_1_bigint
-);
+make_udf_function!(repeat_impl::repeat_1_bigintFunc, REPEAT_1_BIGINT, repeat_1_bigint);
 
-make_udf_function!(
-    replace_impl::replace_varchar_varchar_varcharFunc,
-    REPLACE_VARCHAR_VARCHAR_VARCHAR,
-    replace_varchar_varchar_varchar
-);
-make_udf_function!(
-    replace_impl::replace_varchar_varcharFunc,
-    REPLACE_VARCHAR_VARCHAR,
-    replace_varchar_varchar
-);
+make_udf_function!(replace_impl::replace_varchar_varchar_varcharFunc, REPLACE_VARCHAR_VARCHAR_VARCHAR, replace_varchar_varchar_varchar);
+make_udf_function!(replace_impl::replace_varchar_varcharFunc, REPLACE_VARCHAR_VARCHAR, replace_varchar_varchar);
 
-make_udf_function!(
-    reverse_impl::reverse_array_3Func,
-    REVERSE_ARRAY_3,
-    reverse_array_3
-);
-make_udf_function!(
-    reverse_impl::reverse_varbinaryFunc,
-    REVERSE_VARBINARY,
-    reverse_varbinary
-);
-make_udf_function!(
-    reverse_impl::reverse_varcharFunc,
-    REVERSE_VARCHAR,
-    reverse_varchar
-);
+make_udf_function!(reverse_impl::reverse_array_3Func, REVERSE_ARRAY_3, reverse_array_3);
+make_udf_function!(reverse_impl::reverse_varbinaryFunc, REVERSE_VARBINARY, reverse_varbinary);
+make_udf_function!(reverse_impl::reverse_varcharFunc, REVERSE_VARCHAR, reverse_varchar);
 
-make_udf_function!(
-    rgb_impl::rgb_bigint_bigint_bigintFunc,
-    RGB_BIGINT_BIGINT_BIGINT,
-    rgb_bigint_bigint_bigint
-);
+make_udf_function!(rgb_impl::rgb_bigint_bigint_bigintFunc, RGB_BIGINT_BIGINT_BIGINT, rgb_bigint_bigint_bigint);
 
 make_udf_function!(round_impl::round_doubleFunc, ROUND_DOUBLE, round_double);
-make_udf_function!(
-    round_impl::round_double_bigintFunc,
-    ROUND_DOUBLE_BIGINT,
-    round_double_bigint
-);
+make_udf_function!(round_impl::round_double_bigintFunc, ROUND_DOUBLE_BIGINT, round_double_bigint);
 make_udf_function!(round_impl::round_realFunc, ROUND_REAL, round_real);
-make_udf_function!(
-    round_impl::round_real_bigintFunc,
-    ROUND_REAL_BIGINT,
-    round_real_bigint
-);
+make_udf_function!(round_impl::round_real_bigintFunc, ROUND_REAL_BIGINT, round_real_bigint);
 make_udf_function!(round_impl::round_integerFunc, ROUND_INTEGER, round_integer);
-make_udf_function!(
-    round_impl::round_integer_integerFunc,
-    ROUND_INTEGER_INTEGER,
-    round_integer_integer
-);
-make_udf_function!(
-    round_impl::round_decimal_p_sFunc,
-    ROUND_DECIMAL_P_S,
-    round_decimal_p_s
-);
-make_udf_function!(
-    round_impl::round_decimal_p_s_bigintFunc,
-    ROUND_DECIMAL_P_S_BIGINT,
-    round_decimal_p_s_bigint
-);
+make_udf_function!(round_impl::round_integer_integerFunc, ROUND_INTEGER_INTEGER, round_integer_integer);
+make_udf_function!(round_impl::round_decimal_p_sFunc, ROUND_DECIMAL_P_S, round_decimal_p_s);
+make_udf_function!(round_impl::round_decimal_p_s_bigintFunc, ROUND_DECIMAL_P_S_BIGINT, round_decimal_p_s_bigint);
 make_udf_function!(round_impl::round_bigintFunc, ROUND_BIGINT, round_bigint);
-make_udf_function!(
-    round_impl::round_bigint_bigintFunc,
-    ROUND_BIGINT_BIGINT,
-    round_bigint_bigint
-);
-make_udf_function!(
-    round_impl::round_smallintFunc,
-    ROUND_SMALLINT,
-    round_smallint
-);
-make_udf_function!(
-    round_impl::round_smallint_bigintFunc,
-    ROUND_SMALLINT_BIGINT,
-    round_smallint_bigint
-);
+make_udf_function!(round_impl::round_bigint_bigintFunc, ROUND_BIGINT_BIGINT, round_bigint_bigint);
+make_udf_function!(round_impl::round_smallintFunc, ROUND_SMALLINT, round_smallint);
+make_udf_function!(round_impl::round_smallint_bigintFunc, ROUND_SMALLINT_BIGINT, round_smallint_bigint);
 make_udf_function!(round_impl::round_tinyintFunc, ROUND_TINYINT, round_tinyint);
-make_udf_function!(
-    round_impl::round_tinyint_bigintFunc,
-    ROUND_TINYINT_BIGINT,
-    round_tinyint_bigint
-);
+make_udf_function!(round_impl::round_tinyint_bigintFunc, ROUND_TINYINT_BIGINT, round_tinyint_bigint);
 
-make_udf_function!(
-    rpad_impl::rpad_varbinary_bigint_varbinaryFunc,
-    RPAD_VARBINARY_BIGINT_VARBINARY,
-    rpad_varbinary_bigint_varbinary
-);
-make_udf_function!(
-    rpad_impl::rpad_varchar_bigint_varcharFunc,
-    RPAD_VARCHAR_BIGINT_VARCHAR,
-    rpad_varchar_bigint_varchar
-);
+make_udf_function!(rpad_impl::rpad_varbinary_bigint_varbinaryFunc, RPAD_VARBINARY_BIGINT_VARBINARY, rpad_varbinary_bigint_varbinary);
+make_udf_function!(rpad_impl::rpad_varchar_bigint_varcharFunc, RPAD_VARCHAR_BIGINT_VARCHAR, rpad_varchar_bigint_varchar);
 
 make_udf_function!(rtrim_impl::rtrim_varcharFunc, RTRIM_VARCHAR, rtrim_varchar);
-make_udf_function!(
-    rtrim_impl::rtrim_varchar_codepointsFunc,
-    RTRIM_VARCHAR_CODEPOINTS,
-    rtrim_varchar_codepoints
-);
+make_udf_function!(rtrim_impl::rtrim_varchar_codepointsFunc, RTRIM_VARCHAR_CODEPOINTS, rtrim_varchar_codepoints);
 
-make_udf_function!(
-    second_impl::second_intervaldaytosecondFunc,
-    SECOND_INTERVALDAYTOSECOND,
-    second_intervaldaytosecond
-);
+make_udf_function!(second_impl::second_intervaldaytosecondFunc, SECOND_INTERVALDAYTOSECOND, second_intervaldaytosecond);
 make_udf_function!(second_impl::second_time_pFunc, SECOND_TIME_P, second_time_p);
-make_udf_function!(
-    second_impl::second_timestamp_pFunc,
-    SECOND_TIMESTAMP_P,
-    second_timestamp_p
-);
+make_udf_function!(second_impl::second_timestamp_pFunc, SECOND_TIMESTAMP_P, second_timestamp_p);
 
-make_udf_function!(
-    sequence_impl::sequence_bigint_bigintFunc,
-    SEQUENCE_BIGINT_BIGINT,
-    sequence_bigint_bigint
-);
-make_udf_function!(
-    sequence_impl::sequence_bigint_bigint_bigintFunc,
-    SEQUENCE_BIGINT_BIGINT_BIGINT,
-    sequence_bigint_bigint_bigint
-);
-make_udf_function!(
-    sequence_impl::sequence_date_dateFunc,
-    SEQUENCE_DATE_DATE,
-    sequence_date_date
-);
-make_udf_function!(
-    sequence_impl::sequence_date_date_intervaldaytosecondFunc,
-    SEQUENCE_DATE_DATE_INTERVALDAYTOSECOND,
-    sequence_date_date_intervaldaytosecond
-);
-make_udf_function!(
-    sequence_impl::sequence_date_date_intervalyeartomonthFunc,
-    SEQUENCE_DATE_DATE_INTERVALYEARTOMONTH,
-    sequence_date_date_intervalyeartomonth
-);
-make_udf_function!(
-    sequence_impl::sequence_timestamp_p_timestamp_p_intervaldaytosecondFunc,
-    SEQUENCE_TIMESTAMP_P_TIMESTAMP_P_INTERVALDAYTOSECOND,
-    sequence_timestamp_p_timestamp_p_intervaldaytosecond
-);
+make_udf_function!(sequence_impl::sequence_bigint_bigintFunc, SEQUENCE_BIGINT_BIGINT, sequence_bigint_bigint);
+make_udf_function!(sequence_impl::sequence_bigint_bigint_bigintFunc, SEQUENCE_BIGINT_BIGINT_BIGINT, sequence_bigint_bigint_bigint);
+make_udf_function!(sequence_impl::sequence_date_dateFunc, SEQUENCE_DATE_DATE, sequence_date_date);
+make_udf_function!(sequence_impl::sequence_date_date_intervaldaytosecondFunc, SEQUENCE_DATE_DATE_INTERVALDAYTOSECOND, sequence_date_date_intervaldaytosecond);
+make_udf_function!(sequence_impl::sequence_date_date_intervalyeartomonthFunc, SEQUENCE_DATE_DATE_INTERVALYEARTOMONTH, sequence_date_date_intervalyeartomonth);
+make_udf_function!(sequence_impl::sequence_timestamp_p_timestamp_p_intervaldaytosecondFunc, SEQUENCE_TIMESTAMP_P_TIMESTAMP_P_INTERVALDAYTOSECOND, sequence_timestamp_p_timestamp_p_intervaldaytosecond);
 
-make_udf_function!(
-    sha1_impl::sha1_varbinaryFunc,
-    SHA1_VARBINARY,
-    sha1_varbinary
-);
+make_udf_function!(sha1_impl::sha1_varbinaryFunc, SHA1_VARBINARY, sha1_varbinary);
 
-make_udf_function!(
-    sha256_impl::sha256_varbinaryFunc,
-    SHA256_VARBINARY,
-    sha256_varbinary
-);
+make_udf_function!(sha256_impl::sha256_varbinaryFunc, SHA256_VARBINARY, sha256_varbinary);
 
-make_udf_function!(
-    sha512_impl::sha512_varbinaryFunc,
-    SHA512_VARBINARY,
-    sha512_varbinary
-);
+make_udf_function!(sha512_impl::sha512_varbinaryFunc, SHA512_VARBINARY, sha512_varbinary);
 
-make_udf_function!(
-    shuffle_impl::shuffle_array_3Func,
-    SHUFFLE_ARRAY_3,
-    shuffle_array_3
-);
+make_udf_function!(shuffle_impl::shuffle_array_3Func, SHUFFLE_ARRAY_3, shuffle_array_3);
 
 make_udf_function!(sign_impl::sign_bigintFunc, SIGN_BIGINT, sign_bigint);
-make_udf_function!(
-    sign_impl::sign_decimal_p_sFunc,
-    SIGN_DECIMAL_P_S,
-    sign_decimal_p_s
-);
+make_udf_function!(sign_impl::sign_decimal_p_sFunc, SIGN_DECIMAL_P_S, sign_decimal_p_s);
 make_udf_function!(sign_impl::sign_doubleFunc, SIGN_DOUBLE, sign_double);
 make_udf_function!(sign_impl::sign_integerFunc, SIGN_INTEGER, sign_integer);
 make_udf_function!(sign_impl::sign_realFunc, SIGN_REAL, sign_real);
 make_udf_function!(sign_impl::sign_smallintFunc, SIGN_SMALLINT, sign_smallint);
 make_udf_function!(sign_impl::sign_tinyintFunc, SIGN_TINYINT, sign_tinyint);
 
-make_udf_function!(
-    simplify_geometry_impl::simplify_geometry_geometry_doubleFunc,
-    SIMPLIFY_GEOMETRY_GEOMETRY_DOUBLE,
-    simplify_geometry_geometry_double
-);
+make_udf_function!(simplify_geometry_impl::simplify_geometry_geometry_doubleFunc, SIMPLIFY_GEOMETRY_GEOMETRY_DOUBLE, simplify_geometry_geometry_double);
 
 make_udf_function!(sin_impl::sin_doubleFunc, SIN_DOUBLE, sin_double);
 
 make_udf_function!(sinh_impl::sinh_doubleFunc, SINH_DOUBLE, sinh_double);
 
-make_udf_function!(
-    slice_impl::slice_array_3_bigint_bigintFunc,
-    SLICE_ARRAY_3_BIGINT_BIGINT,
-    slice_array_3_bigint_bigint
-);
+make_udf_function!(slice_impl::slice_array_3_bigint_bigintFunc, SLICE_ARRAY_3_BIGINT_BIGINT, slice_array_3_bigint_bigint);
 
-make_udf_function!(
-    soundex_impl::soundex_varcharFunc,
-    SOUNDEX_VARCHAR,
-    soundex_varchar
-);
+make_udf_function!(soundex_impl::soundex_varcharFunc, SOUNDEX_VARCHAR, soundex_varchar);
 
-make_udf_function!(
-    spatial_partitions_impl::spatial_partitions_kdbtree_geometryFunc,
-    SPATIAL_PARTITIONS_KDBTREE_GEOMETRY,
-    spatial_partitions_kdbtree_geometry
-);
-make_udf_function!(
-    spatial_partitions_impl::spatial_partitions_kdbtree_geometry_doubleFunc,
-    SPATIAL_PARTITIONS_KDBTREE_GEOMETRY_DOUBLE,
-    spatial_partitions_kdbtree_geometry_double
-);
+make_udf_function!(spatial_partitions_impl::spatial_partitions_kdbtree_geometryFunc, SPATIAL_PARTITIONS_KDBTREE_GEOMETRY, spatial_partitions_kdbtree_geometry);
+make_udf_function!(spatial_partitions_impl::spatial_partitions_kdbtree_geometry_doubleFunc, SPATIAL_PARTITIONS_KDBTREE_GEOMETRY_DOUBLE, spatial_partitions_kdbtree_geometry_double);
 
-make_udf_function!(
-    split_impl::split_varchar_varcharFunc,
-    SPLIT_VARCHAR_VARCHAR,
-    split_varchar_varchar
-);
-make_udf_function!(
-    split_impl::split_varchar_varchar_bigintFunc,
-    SPLIT_VARCHAR_VARCHAR_BIGINT,
-    split_varchar_varchar_bigint
-);
+make_udf_function!(split_impl::split_varchar_varcharFunc, SPLIT_VARCHAR_VARCHAR, split_varchar_varchar);
+make_udf_function!(split_impl::split_varchar_varchar_bigintFunc, SPLIT_VARCHAR_VARCHAR_BIGINT, split_varchar_varchar_bigint);
 
-make_udf_function!(
-    split_part_impl::split_part_varchar_varchar_bigintFunc,
-    SPLIT_PART_VARCHAR_VARCHAR_BIGINT,
-    split_part_varchar_varchar_bigint
-);
+make_udf_function!(split_part_impl::split_part_varchar_varchar_bigintFunc, SPLIT_PART_VARCHAR_VARCHAR_BIGINT, split_part_varchar_varchar_bigint);
 
-make_udf_function!(
-    split_to_map_impl::split_to_map_varchar_varchar_varcharFunc,
-    SPLIT_TO_MAP_VARCHAR_VARCHAR_VARCHAR,
-    split_to_map_varchar_varchar_varchar
-);
+make_udf_function!(split_to_map_impl::split_to_map_varchar_varchar_varcharFunc, SPLIT_TO_MAP_VARCHAR_VARCHAR_VARCHAR, split_to_map_varchar_varchar_varchar);
 
-make_udf_function!(
-    split_to_multimap_impl::split_to_multimap_varchar_varchar_varcharFunc,
-    SPLIT_TO_MULTIMAP_VARCHAR_VARCHAR_VARCHAR,
-    split_to_multimap_varchar_varchar_varchar
-);
+make_udf_function!(split_to_multimap_impl::split_to_multimap_varchar_varchar_varcharFunc, SPLIT_TO_MULTIMAP_VARCHAR_VARCHAR_VARCHAR, split_to_multimap_varchar_varchar_varchar);
 
-make_udf_function!(
-    spooky_hash_v2_32_impl::spooky_hash_v2_32_varbinaryFunc,
-    SPOOKY_HASH_V2_32_VARBINARY,
-    spooky_hash_v2_32_varbinary
-);
+make_udf_function!(spooky_hash_v2_32_impl::spooky_hash_v2_32_varbinaryFunc, SPOOKY_HASH_V2_32_VARBINARY, spooky_hash_v2_32_varbinary);
 
-make_udf_function!(
-    spooky_hash_v2_64_impl::spooky_hash_v2_64_varbinaryFunc,
-    SPOOKY_HASH_V2_64_VARBINARY,
-    spooky_hash_v2_64_varbinary
-);
+make_udf_function!(spooky_hash_v2_64_impl::spooky_hash_v2_64_varbinaryFunc, SPOOKY_HASH_V2_64_VARBINARY, spooky_hash_v2_64_varbinary);
 
 make_udf_function!(sqrt_impl::sqrt_doubleFunc, SQRT_DOUBLE, sqrt_double);
 
-make_udf_function!(
-    st_area_impl::st_area_geometryFunc,
-    ST_AREA_GEOMETRY,
-    st_area_geometry
-);
-make_udf_function!(
-    st_area_impl::st_area_sphericalgeographyFunc,
-    ST_AREA_SPHERICALGEOGRAPHY,
-    st_area_sphericalgeography
-);
+make_udf_function!(st_area_impl::st_area_geometryFunc, ST_AREA_GEOMETRY, st_area_geometry);
+make_udf_function!(st_area_impl::st_area_sphericalgeographyFunc, ST_AREA_SPHERICALGEOGRAPHY, st_area_sphericalgeography);
 
-make_udf_function!(
-    st_asbinary_impl::st_asbinary_geometryFunc,
-    ST_ASBINARY_GEOMETRY,
-    st_asbinary_geometry
-);
+make_udf_function!(st_asbinary_impl::st_asbinary_geometryFunc, ST_ASBINARY_GEOMETRY, st_asbinary_geometry);
 
-make_udf_function!(
-    st_astext_impl::st_astext_geometryFunc,
-    ST_ASTEXT_GEOMETRY,
-    st_astext_geometry
-);
+make_udf_function!(st_astext_impl::st_astext_geometryFunc, ST_ASTEXT_GEOMETRY, st_astext_geometry);
 
-make_udf_function!(
-    st_boundary_impl::st_boundary_geometryFunc,
-    ST_BOUNDARY_GEOMETRY,
-    st_boundary_geometry
-);
+make_udf_function!(st_boundary_impl::st_boundary_geometryFunc, ST_BOUNDARY_GEOMETRY, st_boundary_geometry);
 
-make_udf_function!(
-    st_buffer_impl::st_buffer_geometry_doubleFunc,
-    ST_BUFFER_GEOMETRY_DOUBLE,
-    st_buffer_geometry_double
-);
+make_udf_function!(st_buffer_impl::st_buffer_geometry_doubleFunc, ST_BUFFER_GEOMETRY_DOUBLE, st_buffer_geometry_double);
 
-make_udf_function!(
-    st_centroid_impl::st_centroid_geometryFunc,
-    ST_CENTROID_GEOMETRY,
-    st_centroid_geometry
-);
+make_udf_function!(st_centroid_impl::st_centroid_geometryFunc, ST_CENTROID_GEOMETRY, st_centroid_geometry);
 
-make_udf_function!(
-    st_contains_impl::st_contains_geometry_geometryFunc,
-    ST_CONTAINS_GEOMETRY_GEOMETRY,
-    st_contains_geometry_geometry
-);
+make_udf_function!(st_contains_impl::st_contains_geometry_geometryFunc, ST_CONTAINS_GEOMETRY_GEOMETRY, st_contains_geometry_geometry);
 
-make_udf_function!(
-    st_convexhull_impl::st_convexhull_geometryFunc,
-    ST_CONVEXHULL_GEOMETRY,
-    st_convexhull_geometry
-);
+make_udf_function!(st_convexhull_impl::st_convexhull_geometryFunc, ST_CONVEXHULL_GEOMETRY, st_convexhull_geometry);
 
-make_udf_function!(
-    st_coorddim_impl::st_coorddim_geometryFunc,
-    ST_COORDDIM_GEOMETRY,
-    st_coorddim_geometry
-);
+make_udf_function!(st_coorddim_impl::st_coorddim_geometryFunc, ST_COORDDIM_GEOMETRY, st_coorddim_geometry);
 
-make_udf_function!(
-    st_crosses_impl::st_crosses_geometry_geometryFunc,
-    ST_CROSSES_GEOMETRY_GEOMETRY,
-    st_crosses_geometry_geometry
-);
+make_udf_function!(st_crosses_impl::st_crosses_geometry_geometryFunc, ST_CROSSES_GEOMETRY_GEOMETRY, st_crosses_geometry_geometry);
 
-make_udf_function!(
-    st_difference_impl::st_difference_geometry_geometryFunc,
-    ST_DIFFERENCE_GEOMETRY_GEOMETRY,
-    st_difference_geometry_geometry
-);
+make_udf_function!(st_difference_impl::st_difference_geometry_geometryFunc, ST_DIFFERENCE_GEOMETRY_GEOMETRY, st_difference_geometry_geometry);
 
-make_udf_function!(
-    st_dimension_impl::st_dimension_geometryFunc,
-    ST_DIMENSION_GEOMETRY,
-    st_dimension_geometry
-);
+make_udf_function!(st_dimension_impl::st_dimension_geometryFunc, ST_DIMENSION_GEOMETRY, st_dimension_geometry);
 
-make_udf_function!(
-    st_disjoint_impl::st_disjoint_geometry_geometryFunc,
-    ST_DISJOINT_GEOMETRY_GEOMETRY,
-    st_disjoint_geometry_geometry
-);
+make_udf_function!(st_disjoint_impl::st_disjoint_geometry_geometryFunc, ST_DISJOINT_GEOMETRY_GEOMETRY, st_disjoint_geometry_geometry);
 
-make_udf_function!(
-    st_distance_impl::st_distance_geometry_geometryFunc,
-    ST_DISTANCE_GEOMETRY_GEOMETRY,
-    st_distance_geometry_geometry
-);
-make_udf_function!(
-    st_distance_impl::st_distance_sphericalgeography_sphericalgeographyFunc,
-    ST_DISTANCE_SPHERICALGEOGRAPHY_SPHERICALGEOGRAPHY,
-    st_distance_sphericalgeography_sphericalgeography
-);
+make_udf_function!(st_distance_impl::st_distance_geometry_geometryFunc, ST_DISTANCE_GEOMETRY_GEOMETRY, st_distance_geometry_geometry);
+make_udf_function!(st_distance_impl::st_distance_sphericalgeography_sphericalgeographyFunc, ST_DISTANCE_SPHERICALGEOGRAPHY_SPHERICALGEOGRAPHY, st_distance_sphericalgeography_sphericalgeography);
 
-make_udf_function!(
-    st_endpoint_impl::st_endpoint_geometryFunc,
-    ST_ENDPOINT_GEOMETRY,
-    st_endpoint_geometry
-);
+make_udf_function!(st_endpoint_impl::st_endpoint_geometryFunc, ST_ENDPOINT_GEOMETRY, st_endpoint_geometry);
 
-make_udf_function!(
-    st_envelope_impl::st_envelope_geometryFunc,
-    ST_ENVELOPE_GEOMETRY,
-    st_envelope_geometry
-);
+make_udf_function!(st_envelope_impl::st_envelope_geometryFunc, ST_ENVELOPE_GEOMETRY, st_envelope_geometry);
 
-make_udf_function!(
-    st_envelopeaspts_impl::st_envelopeaspts_geometryFunc,
-    ST_ENVELOPEASPTS_GEOMETRY,
-    st_envelopeaspts_geometry
-);
+make_udf_function!(st_envelopeaspts_impl::st_envelopeaspts_geometryFunc, ST_ENVELOPEASPTS_GEOMETRY, st_envelopeaspts_geometry);
 
-make_udf_function!(
-    st_equals_impl::st_equals_geometry_geometryFunc,
-    ST_EQUALS_GEOMETRY_GEOMETRY,
-    st_equals_geometry_geometry
-);
+make_udf_function!(st_equals_impl::st_equals_geometry_geometryFunc, ST_EQUALS_GEOMETRY_GEOMETRY, st_equals_geometry_geometry);
 
-make_udf_function!(
-    st_exteriorring_impl::st_exteriorring_geometryFunc,
-    ST_EXTERIORRING_GEOMETRY,
-    st_exteriorring_geometry
-);
+make_udf_function!(st_exteriorring_impl::st_exteriorring_geometryFunc, ST_EXTERIORRING_GEOMETRY, st_exteriorring_geometry);
 
-make_udf_function!(
-    st_geometries_impl::st_geometries_geometryFunc,
-    ST_GEOMETRIES_GEOMETRY,
-    st_geometries_geometry
-);
+make_udf_function!(st_geometries_impl::st_geometries_geometryFunc, ST_GEOMETRIES_GEOMETRY, st_geometries_geometry);
 
-make_udf_function!(
-    st_geometryfromtext_impl::st_geometryfromtext_varcharFunc,
-    ST_GEOMETRYFROMTEXT_VARCHAR,
-    st_geometryfromtext_varchar
-);
+make_udf_function!(st_geometryfromtext_impl::st_geometryfromtext_varcharFunc, ST_GEOMETRYFROMTEXT_VARCHAR, st_geometryfromtext_varchar);
 
-make_udf_function!(
-    st_geometryn_impl::st_geometryn_geometry_bigintFunc,
-    ST_GEOMETRYN_GEOMETRY_BIGINT,
-    st_geometryn_geometry_bigint
-);
+make_udf_function!(st_geometryn_impl::st_geometryn_geometry_bigintFunc, ST_GEOMETRYN_GEOMETRY_BIGINT, st_geometryn_geometry_bigint);
 
-make_udf_function!(
-    st_geometrytype_impl::st_geometrytype_geometryFunc,
-    ST_GEOMETRYTYPE_GEOMETRY,
-    st_geometrytype_geometry
-);
+make_udf_function!(st_geometrytype_impl::st_geometrytype_geometryFunc, ST_GEOMETRYTYPE_GEOMETRY, st_geometrytype_geometry);
 
-make_udf_function!(
-    st_geomfrombinary_impl::st_geomfrombinary_varbinaryFunc,
-    ST_GEOMFROMBINARY_VARBINARY,
-    st_geomfrombinary_varbinary
-);
+make_udf_function!(st_geomfrombinary_impl::st_geomfrombinary_varbinaryFunc, ST_GEOMFROMBINARY_VARBINARY, st_geomfrombinary_varbinary);
 
-make_udf_function!(
-    st_interiorringn_impl::st_interiorringn_geometry_bigintFunc,
-    ST_INTERIORRINGN_GEOMETRY_BIGINT,
-    st_interiorringn_geometry_bigint
-);
+make_udf_function!(st_interiorringn_impl::st_interiorringn_geometry_bigintFunc, ST_INTERIORRINGN_GEOMETRY_BIGINT, st_interiorringn_geometry_bigint);
 
-make_udf_function!(
-    st_interiorrings_impl::st_interiorrings_geometryFunc,
-    ST_INTERIORRINGS_GEOMETRY,
-    st_interiorrings_geometry
-);
+make_udf_function!(st_interiorrings_impl::st_interiorrings_geometryFunc, ST_INTERIORRINGS_GEOMETRY, st_interiorrings_geometry);
 
-make_udf_function!(
-    st_intersection_impl::st_intersection_geometry_geometryFunc,
-    ST_INTERSECTION_GEOMETRY_GEOMETRY,
-    st_intersection_geometry_geometry
-);
+make_udf_function!(st_intersection_impl::st_intersection_geometry_geometryFunc, ST_INTERSECTION_GEOMETRY_GEOMETRY, st_intersection_geometry_geometry);
 
-make_udf_function!(
-    st_intersects_impl::st_intersects_geometry_geometryFunc,
-    ST_INTERSECTS_GEOMETRY_GEOMETRY,
-    st_intersects_geometry_geometry
-);
+make_udf_function!(st_intersects_impl::st_intersects_geometry_geometryFunc, ST_INTERSECTS_GEOMETRY_GEOMETRY, st_intersects_geometry_geometry);
 
-make_udf_function!(
-    st_isclosed_impl::st_isclosed_geometryFunc,
-    ST_ISCLOSED_GEOMETRY,
-    st_isclosed_geometry
-);
+make_udf_function!(st_isclosed_impl::st_isclosed_geometryFunc, ST_ISCLOSED_GEOMETRY, st_isclosed_geometry);
 
-make_udf_function!(
-    st_isempty_impl::st_isempty_geometryFunc,
-    ST_ISEMPTY_GEOMETRY,
-    st_isempty_geometry
-);
+make_udf_function!(st_isempty_impl::st_isempty_geometryFunc, ST_ISEMPTY_GEOMETRY, st_isempty_geometry);
 
-make_udf_function!(
-    st_isring_impl::st_isring_geometryFunc,
-    ST_ISRING_GEOMETRY,
-    st_isring_geometry
-);
+make_udf_function!(st_isring_impl::st_isring_geometryFunc, ST_ISRING_GEOMETRY, st_isring_geometry);
 
-make_udf_function!(
-    st_issimple_impl::st_issimple_geometryFunc,
-    ST_ISSIMPLE_GEOMETRY,
-    st_issimple_geometry
-);
+make_udf_function!(st_issimple_impl::st_issimple_geometryFunc, ST_ISSIMPLE_GEOMETRY, st_issimple_geometry);
 
-make_udf_function!(
-    st_isvalid_impl::st_isvalid_geometryFunc,
-    ST_ISVALID_GEOMETRY,
-    st_isvalid_geometry
-);
+make_udf_function!(st_isvalid_impl::st_isvalid_geometryFunc, ST_ISVALID_GEOMETRY, st_isvalid_geometry);
 
-make_udf_function!(
-    st_length_impl::st_length_geometryFunc,
-    ST_LENGTH_GEOMETRY,
-    st_length_geometry
-);
-make_udf_function!(
-    st_length_impl::st_length_sphericalgeographyFunc,
-    ST_LENGTH_SPHERICALGEOGRAPHY,
-    st_length_sphericalgeography
-);
+make_udf_function!(st_length_impl::st_length_geometryFunc, ST_LENGTH_GEOMETRY, st_length_geometry);
+make_udf_function!(st_length_impl::st_length_sphericalgeographyFunc, ST_LENGTH_SPHERICALGEOGRAPHY, st_length_sphericalgeography);
 
-make_udf_function!(
-    st_linefromtext_impl::st_linefromtext_varcharFunc,
-    ST_LINEFROMTEXT_VARCHAR,
-    st_linefromtext_varchar
-);
+make_udf_function!(st_linefromtext_impl::st_linefromtext_varcharFunc, ST_LINEFROMTEXT_VARCHAR, st_linefromtext_varchar);
 
-make_udf_function!(
-    st_linestring_impl::st_linestring_array_geometryFunc,
-    ST_LINESTRING_ARRAY_GEOMETRY,
-    st_linestring_array_geometry
-);
+make_udf_function!(st_linestring_impl::st_linestring_array_geometryFunc, ST_LINESTRING_ARRAY_GEOMETRY, st_linestring_array_geometry);
 
-make_udf_function!(
-    st_multipoint_impl::st_multipoint_array_geometryFunc,
-    ST_MULTIPOINT_ARRAY_GEOMETRY,
-    st_multipoint_array_geometry
-);
+make_udf_function!(st_multipoint_impl::st_multipoint_array_geometryFunc, ST_MULTIPOINT_ARRAY_GEOMETRY, st_multipoint_array_geometry);
 
-make_udf_function!(
-    st_numgeometries_impl::st_numgeometries_geometryFunc,
-    ST_NUMGEOMETRIES_GEOMETRY,
-    st_numgeometries_geometry
-);
+make_udf_function!(st_numgeometries_impl::st_numgeometries_geometryFunc, ST_NUMGEOMETRIES_GEOMETRY, st_numgeometries_geometry);
 
-make_udf_function!(
-    st_numinteriorring_impl::st_numinteriorring_geometryFunc,
-    ST_NUMINTERIORRING_GEOMETRY,
-    st_numinteriorring_geometry
-);
+make_udf_function!(st_numinteriorring_impl::st_numinteriorring_geometryFunc, ST_NUMINTERIORRING_GEOMETRY, st_numinteriorring_geometry);
 
-make_udf_function!(
-    st_numpoints_impl::st_numpoints_geometryFunc,
-    ST_NUMPOINTS_GEOMETRY,
-    st_numpoints_geometry
-);
+make_udf_function!(st_numpoints_impl::st_numpoints_geometryFunc, ST_NUMPOINTS_GEOMETRY, st_numpoints_geometry);
 
-make_udf_function!(
-    st_overlaps_impl::st_overlaps_geometry_geometryFunc,
-    ST_OVERLAPS_GEOMETRY_GEOMETRY,
-    st_overlaps_geometry_geometry
-);
+make_udf_function!(st_overlaps_impl::st_overlaps_geometry_geometryFunc, ST_OVERLAPS_GEOMETRY_GEOMETRY, st_overlaps_geometry_geometry);
 
-make_udf_function!(
-    st_point_impl::st_point_double_doubleFunc,
-    ST_POINT_DOUBLE_DOUBLE,
-    st_point_double_double
-);
+make_udf_function!(st_point_impl::st_point_double_doubleFunc, ST_POINT_DOUBLE_DOUBLE, st_point_double_double);
 
-make_udf_function!(
-    st_pointn_impl::st_pointn_geometry_bigintFunc,
-    ST_POINTN_GEOMETRY_BIGINT,
-    st_pointn_geometry_bigint
-);
+make_udf_function!(st_pointn_impl::st_pointn_geometry_bigintFunc, ST_POINTN_GEOMETRY_BIGINT, st_pointn_geometry_bigint);
 
-make_udf_function!(
-    st_points_impl::st_points_geometryFunc,
-    ST_POINTS_GEOMETRY,
-    st_points_geometry
-);
+make_udf_function!(st_points_impl::st_points_geometryFunc, ST_POINTS_GEOMETRY, st_points_geometry);
 
-make_udf_function!(
-    st_polygon_impl::st_polygon_varcharFunc,
-    ST_POLYGON_VARCHAR,
-    st_polygon_varchar
-);
+make_udf_function!(st_polygon_impl::st_polygon_varcharFunc, ST_POLYGON_VARCHAR, st_polygon_varchar);
 
-make_udf_function!(
-    st_relate_impl::st_relate_geometry_geometry_varcharFunc,
-    ST_RELATE_GEOMETRY_GEOMETRY_VARCHAR,
-    st_relate_geometry_geometry_varchar
-);
+make_udf_function!(st_relate_impl::st_relate_geometry_geometry_varcharFunc, ST_RELATE_GEOMETRY_GEOMETRY_VARCHAR, st_relate_geometry_geometry_varchar);
 
-make_udf_function!(
-    st_startpoint_impl::st_startpoint_geometryFunc,
-    ST_STARTPOINT_GEOMETRY,
-    st_startpoint_geometry
-);
+make_udf_function!(st_startpoint_impl::st_startpoint_geometryFunc, ST_STARTPOINT_GEOMETRY, st_startpoint_geometry);
 
-make_udf_function!(
-    st_symdifference_impl::st_symdifference_geometry_geometryFunc,
-    ST_SYMDIFFERENCE_GEOMETRY_GEOMETRY,
-    st_symdifference_geometry_geometry
-);
+make_udf_function!(st_symdifference_impl::st_symdifference_geometry_geometryFunc, ST_SYMDIFFERENCE_GEOMETRY_GEOMETRY, st_symdifference_geometry_geometry);
 
-make_udf_function!(
-    st_touches_impl::st_touches_geometry_geometryFunc,
-    ST_TOUCHES_GEOMETRY_GEOMETRY,
-    st_touches_geometry_geometry
-);
+make_udf_function!(st_touches_impl::st_touches_geometry_geometryFunc, ST_TOUCHES_GEOMETRY_GEOMETRY, st_touches_geometry_geometry);
 
-make_udf_function!(
-    st_union_impl::st_union_geometry_geometryFunc,
-    ST_UNION_GEOMETRY_GEOMETRY,
-    st_union_geometry_geometry
-);
+make_udf_function!(st_union_impl::st_union_geometry_geometryFunc, ST_UNION_GEOMETRY_GEOMETRY, st_union_geometry_geometry);
 
-make_udf_function!(
-    st_within_impl::st_within_geometry_geometryFunc,
-    ST_WITHIN_GEOMETRY_GEOMETRY,
-    st_within_geometry_geometry
-);
+make_udf_function!(st_within_impl::st_within_geometry_geometryFunc, ST_WITHIN_GEOMETRY_GEOMETRY, st_within_geometry_geometry);
 
 make_udf_function!(st_x_impl::st_x_geometryFunc, ST_X_GEOMETRY, st_x_geometry);
 
-make_udf_function!(
-    st_xmax_impl::st_xmax_geometryFunc,
-    ST_XMAX_GEOMETRY,
-    st_xmax_geometry
-);
+make_udf_function!(st_xmax_impl::st_xmax_geometryFunc, ST_XMAX_GEOMETRY, st_xmax_geometry);
 
-make_udf_function!(
-    st_xmin_impl::st_xmin_geometryFunc,
-    ST_XMIN_GEOMETRY,
-    st_xmin_geometry
-);
+make_udf_function!(st_xmin_impl::st_xmin_geometryFunc, ST_XMIN_GEOMETRY, st_xmin_geometry);
 
 make_udf_function!(st_y_impl::st_y_geometryFunc, ST_Y_GEOMETRY, st_y_geometry);
 
-make_udf_function!(
-    st_ymax_impl::st_ymax_geometryFunc,
-    ST_YMAX_GEOMETRY,
-    st_ymax_geometry
-);
+make_udf_function!(st_ymax_impl::st_ymax_geometryFunc, ST_YMAX_GEOMETRY, st_ymax_geometry);
 
-make_udf_function!(
-    st_ymin_impl::st_ymin_geometryFunc,
-    ST_YMIN_GEOMETRY,
-    st_ymin_geometry
-);
+make_udf_function!(st_ymin_impl::st_ymin_geometryFunc, ST_YMIN_GEOMETRY, st_ymin_geometry);
 
-make_udf_function!(
-    starts_with_impl::starts_with_varchar_varcharFunc,
-    STARTS_WITH_VARCHAR_VARCHAR,
-    starts_with_varchar_varchar
-);
+make_udf_function!(starts_with_impl::starts_with_varchar_varcharFunc, STARTS_WITH_VARCHAR_VARCHAR, starts_with_varchar_varchar);
 
-make_udf_function!(
-    strpos_impl::strpos_varchar_varcharFunc,
-    STRPOS_VARCHAR_VARCHAR,
-    strpos_varchar_varchar
-);
-make_udf_function!(
-    strpos_impl::strpos_varchar_varchar_bigintFunc,
-    STRPOS_VARCHAR_VARCHAR_BIGINT,
-    strpos_varchar_varchar_bigint
-);
+make_udf_function!(strpos_impl::strpos_varchar_varcharFunc, STRPOS_VARCHAR_VARCHAR, strpos_varchar_varchar);
+make_udf_function!(strpos_impl::strpos_varchar_varchar_bigintFunc, STRPOS_VARCHAR_VARCHAR_BIGINT, strpos_varchar_varchar_bigint);
 
-make_udf_function!(
-    substr_impl::substr_varchar_bigintFunc,
-    SUBSTR_VARCHAR_BIGINT,
-    substr_varchar_bigint
-);
-make_udf_function!(
-    substr_impl::substr_varchar_bigint_bigintFunc,
-    SUBSTR_VARCHAR_BIGINT_BIGINT,
-    substr_varchar_bigint_bigint
-);
-make_udf_function!(
-    substr_impl::substr_varbinary_bigintFunc,
-    SUBSTR_VARBINARY_BIGINT,
-    substr_varbinary_bigint
-);
-make_udf_function!(
-    substr_impl::substr_varbinary_bigint_bigintFunc,
-    SUBSTR_VARBINARY_BIGINT_BIGINT,
-    substr_varbinary_bigint_bigint
-);
+make_udf_function!(substr_impl::substr_varchar_bigintFunc, SUBSTR_VARCHAR_BIGINT, substr_varchar_bigint);
+make_udf_function!(substr_impl::substr_varchar_bigint_bigintFunc, SUBSTR_VARCHAR_BIGINT_BIGINT, substr_varchar_bigint_bigint);
+make_udf_function!(substr_impl::substr_varbinary_bigintFunc, SUBSTR_VARBINARY_BIGINT, substr_varbinary_bigint);
+make_udf_function!(substr_impl::substr_varbinary_bigint_bigintFunc, SUBSTR_VARBINARY_BIGINT_BIGINT, substr_varbinary_bigint_bigint);
 
-make_udf_function!(
-    substring_impl::substring_varchar_bigintFunc,
-    SUBSTRING_VARCHAR_BIGINT,
-    substring_varchar_bigint
-);
-make_udf_function!(
-    substring_impl::substring_varchar_bigint_bigintFunc,
-    SUBSTRING_VARCHAR_BIGINT_BIGINT,
-    substring_varchar_bigint_bigint
-);
+make_udf_function!(substring_impl::substring_varchar_bigintFunc, SUBSTRING_VARCHAR_BIGINT, substring_varchar_bigint);
+make_udf_function!(substring_impl::substring_varchar_bigint_bigintFunc, SUBSTRING_VARCHAR_BIGINT_BIGINT, substring_varchar_bigint_bigint);
 
 make_udf_function!(tan_impl::tan_doubleFunc, TAN_DOUBLE, tan_double);
 
 make_udf_function!(tanh_impl::tanh_doubleFunc, TANH_DOUBLE, tanh_double);
 
-make_udf_function!(
-    timestamp_objectid_impl::timestamp_objectid_timestamp_0Func,
-    TIMESTAMP_OBJECTID_TIMESTAMP_0,
-    timestamp_objectid_timestamp_0
-);
+make_udf_function!(timestamp_objectid_impl::timestamp_objectid_timestamp_0Func, TIMESTAMP_OBJECTID_TIMESTAMP_0, timestamp_objectid_timestamp_0);
 
-make_udf_function!(
-    timezone_hour_impl::timezone_hour_time_pFunc,
-    TIMEZONE_HOUR_TIME_P,
-    timezone_hour_time_p
-);
-make_udf_function!(
-    timezone_hour_impl::timezone_hour_timestamp_pFunc,
-    TIMEZONE_HOUR_TIMESTAMP_P,
-    timezone_hour_timestamp_p
-);
+make_udf_function!(timezone_hour_impl::timezone_hour_time_pFunc, TIMEZONE_HOUR_TIME_P, timezone_hour_time_p);
+make_udf_function!(timezone_hour_impl::timezone_hour_timestamp_pFunc, TIMEZONE_HOUR_TIMESTAMP_P, timezone_hour_timestamp_p);
 
-make_udf_function!(
-    timezone_minute_impl::timezone_minute_time_pFunc,
-    TIMEZONE_MINUTE_TIME_P,
-    timezone_minute_time_p
-);
-make_udf_function!(
-    timezone_minute_impl::timezone_minute_timestamp_pFunc,
-    TIMEZONE_MINUTE_TIMESTAMP_P,
-    timezone_minute_timestamp_p
-);
+make_udf_function!(timezone_minute_impl::timezone_minute_time_pFunc, TIMEZONE_MINUTE_TIME_P, timezone_minute_time_p);
+make_udf_function!(timezone_minute_impl::timezone_minute_timestamp_pFunc, TIMEZONE_MINUTE_TIMESTAMP_P, timezone_minute_timestamp_p);
 
-make_udf_function!(
-    to_base_impl::to_base_bigint_bigintFunc,
-    TO_BASE_BIGINT_BIGINT,
-    to_base_bigint_bigint
-);
+make_udf_function!(to_base_impl::to_base_bigint_bigintFunc, TO_BASE_BIGINT_BIGINT, to_base_bigint_bigint);
 
-make_udf_function!(
-    to_base32_impl::to_base32_varbinaryFunc,
-    TO_BASE32_VARBINARY,
-    to_base32_varbinary
-);
+make_udf_function!(to_base32_impl::to_base32_varbinaryFunc, TO_BASE32_VARBINARY, to_base32_varbinary);
 
-make_udf_function!(
-    to_base64_impl::to_base64_varbinaryFunc,
-    TO_BASE64_VARBINARY,
-    to_base64_varbinary
-);
+make_udf_function!(to_base64_impl::to_base64_varbinaryFunc, TO_BASE64_VARBINARY, to_base64_varbinary);
 
-make_udf_function!(
-    to_base64url_impl::to_base64url_varbinaryFunc,
-    TO_BASE64URL_VARBINARY,
-    to_base64url_varbinary
-);
+make_udf_function!(to_base64url_impl::to_base64url_varbinaryFunc, TO_BASE64URL_VARBINARY, to_base64url_varbinary);
 
-make_udf_function!(
-    to_big_endian_32_impl::to_big_endian_32_bigintFunc,
-    TO_BIG_ENDIAN_32_BIGINT,
-    to_big_endian_32_bigint
-);
+make_udf_function!(to_big_endian_32_impl::to_big_endian_32_bigintFunc, TO_BIG_ENDIAN_32_BIGINT, to_big_endian_32_bigint);
 
-make_udf_function!(
-    to_big_endian_64_impl::to_big_endian_64_bigintFunc,
-    TO_BIG_ENDIAN_64_BIGINT,
-    to_big_endian_64_bigint
-);
+make_udf_function!(to_big_endian_64_impl::to_big_endian_64_bigintFunc, TO_BIG_ENDIAN_64_BIGINT, to_big_endian_64_bigint);
 
-make_udf_function!(
-    to_char_impl::to_char_timestamp_p_varcharFunc,
-    TO_CHAR_TIMESTAMP_P_VARCHAR,
-    to_char_timestamp_p_varchar
-);
+make_udf_function!(to_char_impl::to_char_timestamp_p_varcharFunc, TO_CHAR_TIMESTAMP_P_VARCHAR, to_char_timestamp_p_varchar);
 
-make_udf_function!(
-    to_date_impl::to_date_varchar_varcharFunc,
-    TO_DATE_VARCHAR_VARCHAR,
-    to_date_varchar_varchar
-);
+make_udf_function!(to_date_impl::to_date_varchar_varcharFunc, TO_DATE_VARCHAR_VARCHAR, to_date_varchar_varchar);
 
-make_udf_function!(
-    to_encoded_polyline_impl::to_encoded_polyline_geometryFunc,
-    TO_ENCODED_POLYLINE_GEOMETRY,
-    to_encoded_polyline_geometry
-);
+make_udf_function!(to_encoded_polyline_impl::to_encoded_polyline_geometryFunc, TO_ENCODED_POLYLINE_GEOMETRY, to_encoded_polyline_geometry);
 
-make_udf_function!(
-    to_geojson_geometry_impl::to_geojson_geometry_sphericalgeographyFunc,
-    TO_GEOJSON_GEOMETRY_SPHERICALGEOGRAPHY,
-    to_geojson_geometry_sphericalgeography
-);
+make_udf_function!(to_geojson_geometry_impl::to_geojson_geometry_sphericalgeographyFunc, TO_GEOJSON_GEOMETRY_SPHERICALGEOGRAPHY, to_geojson_geometry_sphericalgeography);
 
-make_udf_function!(
-    to_geometry_impl::to_geometry_sphericalgeographyFunc,
-    TO_GEOMETRY_SPHERICALGEOGRAPHY,
-    to_geometry_sphericalgeography
-);
+make_udf_function!(to_geometry_impl::to_geometry_sphericalgeographyFunc, TO_GEOMETRY_SPHERICALGEOGRAPHY, to_geometry_sphericalgeography);
 
-make_udf_function!(
-    to_hex_impl::to_hex_varbinaryFunc,
-    TO_HEX_VARBINARY,
-    to_hex_varbinary
-);
+make_udf_function!(to_hex_impl::to_hex_varbinaryFunc, TO_HEX_VARBINARY, to_hex_varbinary);
 
-make_udf_function!(
-    to_ieee754_32_impl::to_ieee754_32_realFunc,
-    TO_IEEE754_32_REAL,
-    to_ieee754_32_real
-);
+make_udf_function!(to_ieee754_32_impl::to_ieee754_32_realFunc, TO_IEEE754_32_REAL, to_ieee754_32_real);
 
-make_udf_function!(
-    to_ieee754_64_impl::to_ieee754_64_doubleFunc,
-    TO_IEEE754_64_DOUBLE,
-    to_ieee754_64_double
-);
+make_udf_function!(to_ieee754_64_impl::to_ieee754_64_doubleFunc, TO_IEEE754_64_DOUBLE, to_ieee754_64_double);
 
-make_udf_function!(
-    to_iso8601_impl::to_iso8601_dateFunc,
-    TO_ISO8601_DATE,
-    to_iso8601_date
-);
-make_udf_function!(
-    to_iso8601_impl::to_iso8601_timestamp_pFunc,
-    TO_ISO8601_TIMESTAMP_P,
-    to_iso8601_timestamp_p
-);
+make_udf_function!(to_iso8601_impl::to_iso8601_dateFunc, TO_ISO8601_DATE, to_iso8601_date);
+make_udf_function!(to_iso8601_impl::to_iso8601_timestamp_pFunc, TO_ISO8601_TIMESTAMP_P, to_iso8601_timestamp_p);
 
-make_udf_function!(
-    to_milliseconds_impl::to_milliseconds_intervaldaytosecondFunc,
-    TO_MILLISECONDS_INTERVALDAYTOSECOND,
-    to_milliseconds_intervaldaytosecond
-);
+make_udf_function!(to_milliseconds_impl::to_milliseconds_intervaldaytosecondFunc, TO_MILLISECONDS_INTERVALDAYTOSECOND, to_milliseconds_intervaldaytosecond);
 
-make_udf_function!(
-    to_spherical_geography_impl::to_spherical_geography_geometryFunc,
-    TO_SPHERICAL_GEOGRAPHY_GEOMETRY,
-    to_spherical_geography_geometry
-);
+make_udf_function!(to_spherical_geography_impl::to_spherical_geography_geometryFunc, TO_SPHERICAL_GEOGRAPHY_GEOMETRY, to_spherical_geography_geometry);
 
-make_udf_function!(
-    to_timestamp_impl::to_timestamp_varchar_varcharFunc,
-    TO_TIMESTAMP_VARCHAR_VARCHAR,
-    to_timestamp_varchar_varchar
-);
+make_udf_function!(to_timestamp_impl::to_timestamp_varchar_varcharFunc, TO_TIMESTAMP_VARCHAR_VARCHAR, to_timestamp_varchar_varchar);
 
-make_udf_function!(
-    to_unixtime_impl::to_unixtime_timestamp_pFunc,
-    TO_UNIXTIME_TIMESTAMP_P,
-    to_unixtime_timestamp_p
-);
+make_udf_function!(to_unixtime_impl::to_unixtime_timestamp_pFunc, TO_UNIXTIME_TIMESTAMP_P, to_unixtime_timestamp_p);
 
-make_udf_function!(
-    to_utf8_impl::to_utf8_varcharFunc,
-    TO_UTF8_VARCHAR,
-    to_utf8_varchar
-);
+make_udf_function!(to_utf8_impl::to_utf8_varcharFunc, TO_UTF8_VARCHAR, to_utf8_varchar);
 
-make_udf_function!(
-    transform_impl::transform_array_1_function_1_11Func,
-    TRANSFORM_ARRAY_1_FUNCTION_1_11,
-    transform_array_1_function_1_11
-);
+make_udf_function!(transform_impl::transform_array_1_function_1_11Func, TRANSFORM_ARRAY_1_FUNCTION_1_11, transform_array_1_function_1_11);
 
-make_udf_function!(
-    transform_keys_impl::transform_keys_map_13_5_function_13_5_12Func,
-    TRANSFORM_KEYS_MAP_13_5_FUNCTION_13_5_12,
-    transform_keys_map_13_5_function_13_5_12
-);
+make_udf_function!(transform_keys_impl::transform_keys_map_13_5_function_13_5_12Func, TRANSFORM_KEYS_MAP_13_5_FUNCTION_13_5_12, transform_keys_map_13_5_function_13_5_12);
 
-make_udf_function!(
-    transform_values_impl::transform_values_map_4_8_function_4_8_7Func,
-    TRANSFORM_VALUES_MAP_4_8_FUNCTION_4_8_7,
-    transform_values_map_4_8_function_4_8_7
-);
+make_udf_function!(transform_values_impl::transform_values_map_4_8_function_4_8_7Func, TRANSFORM_VALUES_MAP_4_8_FUNCTION_4_8_7, transform_values_map_4_8_function_4_8_7);
 
-make_udf_function!(
-    translate_impl::translate_varchar_varchar_varcharFunc,
-    TRANSLATE_VARCHAR_VARCHAR_VARCHAR,
-    translate_varchar_varchar_varchar
-);
+make_udf_function!(translate_impl::translate_varchar_varchar_varcharFunc, TRANSLATE_VARCHAR_VARCHAR_VARCHAR, translate_varchar_varchar_varchar);
 
 make_udf_function!(trim_impl::trim_varcharFunc, TRIM_VARCHAR, trim_varchar);
-make_udf_function!(
-    trim_impl::trim_varchar_codepointsFunc,
-    TRIM_VARCHAR_CODEPOINTS,
-    trim_varchar_codepoints
-);
+make_udf_function!(trim_impl::trim_varchar_codepointsFunc, TRIM_VARCHAR_CODEPOINTS, trim_varchar_codepoints);
 
-make_udf_function!(
-    trim_array_impl::trim_array_array_3_bigintFunc,
-    TRIM_ARRAY_ARRAY_3_BIGINT,
-    trim_array_array_3_bigint
-);
+make_udf_function!(trim_array_impl::trim_array_array_3_bigintFunc, TRIM_ARRAY_ARRAY_3_BIGINT, trim_array_array_3_bigint);
 
-make_udf_function!(
-    truncate_impl::truncate_decimal_p_s_bigintFunc,
-    TRUNCATE_DECIMAL_P_S_BIGINT,
-    truncate_decimal_p_s_bigint
-);
-make_udf_function!(
-    truncate_impl::truncate_decimal_p_sFunc,
-    TRUNCATE_DECIMAL_P_S,
-    truncate_decimal_p_s
-);
-make_udf_function!(
-    truncate_impl::truncate_doubleFunc,
-    TRUNCATE_DOUBLE,
-    truncate_double
-);
-make_udf_function!(
-    truncate_impl::truncate_realFunc,
-    TRUNCATE_REAL,
-    truncate_real
-);
+make_udf_function!(truncate_impl::truncate_decimal_p_s_bigintFunc, TRUNCATE_DECIMAL_P_S_BIGINT, truncate_decimal_p_s_bigint);
+make_udf_function!(truncate_impl::truncate_decimal_p_sFunc, TRUNCATE_DECIMAL_P_S, truncate_decimal_p_s);
+make_udf_function!(truncate_impl::truncate_doubleFunc, TRUNCATE_DOUBLE, truncate_double);
+make_udf_function!(truncate_impl::truncate_realFunc, TRUNCATE_REAL, truncate_real);
 
 make_udf_function!(try_impl::try_1Func, TRY_1, try_1);
 
@@ -2994,204 +1222,71 @@ make_udf_function!(typeof_impl::typeof_1Func, TYPEOF_1, typeof_1);
 
 make_udf_function!(upper_impl::upper_varcharFunc, UPPER_VARCHAR, upper_varchar);
 
-make_udf_function!(
-    url_decode_impl::url_decode_varcharFunc,
-    URL_DECODE_VARCHAR,
-    url_decode_varchar
-);
+make_udf_function!(url_decode_impl::url_decode_varcharFunc, URL_DECODE_VARCHAR, url_decode_varchar);
 
-make_udf_function!(
-    url_encode_impl::url_encode_varcharFunc,
-    URL_ENCODE_VARCHAR,
-    url_encode_varchar
-);
+make_udf_function!(url_encode_impl::url_encode_varcharFunc, URL_ENCODE_VARCHAR, url_encode_varchar);
 
-make_udf_function!(
-    url_extract_fragment_impl::url_extract_fragment_varcharFunc,
-    URL_EXTRACT_FRAGMENT_VARCHAR,
-    url_extract_fragment_varchar
-);
+make_udf_function!(url_extract_fragment_impl::url_extract_fragment_varcharFunc, URL_EXTRACT_FRAGMENT_VARCHAR, url_extract_fragment_varchar);
 
-make_udf_function!(
-    url_extract_host_impl::url_extract_host_varcharFunc,
-    URL_EXTRACT_HOST_VARCHAR,
-    url_extract_host_varchar
-);
+make_udf_function!(url_extract_host_impl::url_extract_host_varcharFunc, URL_EXTRACT_HOST_VARCHAR, url_extract_host_varchar);
 
-make_udf_function!(
-    url_extract_parameter_impl::url_extract_parameter_varchar_varcharFunc,
-    URL_EXTRACT_PARAMETER_VARCHAR_VARCHAR,
-    url_extract_parameter_varchar_varchar
-);
+make_udf_function!(url_extract_parameter_impl::url_extract_parameter_varchar_varcharFunc, URL_EXTRACT_PARAMETER_VARCHAR_VARCHAR, url_extract_parameter_varchar_varchar);
 
-make_udf_function!(
-    url_extract_path_impl::url_extract_path_varcharFunc,
-    URL_EXTRACT_PATH_VARCHAR,
-    url_extract_path_varchar
-);
+make_udf_function!(url_extract_path_impl::url_extract_path_varcharFunc, URL_EXTRACT_PATH_VARCHAR, url_extract_path_varchar);
 
-make_udf_function!(
-    url_extract_port_impl::url_extract_port_varcharFunc,
-    URL_EXTRACT_PORT_VARCHAR,
-    url_extract_port_varchar
-);
+make_udf_function!(url_extract_port_impl::url_extract_port_varcharFunc, URL_EXTRACT_PORT_VARCHAR, url_extract_port_varchar);
 
-make_udf_function!(
-    url_extract_protocol_impl::url_extract_protocol_varcharFunc,
-    URL_EXTRACT_PROTOCOL_VARCHAR,
-    url_extract_protocol_varchar
-);
+make_udf_function!(url_extract_protocol_impl::url_extract_protocol_varcharFunc, URL_EXTRACT_PROTOCOL_VARCHAR, url_extract_protocol_varchar);
 
-make_udf_function!(
-    url_extract_query_impl::url_extract_query_varcharFunc,
-    URL_EXTRACT_QUERY_VARCHAR,
-    url_extract_query_varchar
-);
+make_udf_function!(url_extract_query_impl::url_extract_query_varcharFunc, URL_EXTRACT_QUERY_VARCHAR, url_extract_query_varchar);
 
 make_udf_function!(uuid_impl::uuidFunc, UUID, uuid);
 
-make_udf_function!(
-    value_at_quantile_impl::value_at_quantile_qdigest_doubleFunc,
-    VALUE_AT_QUANTILE_QDIGEST_DOUBLE,
-    value_at_quantile_qdigest_double
-);
-make_udf_function!(
-    value_at_quantile_impl::value_at_quantile_tdigest_doubleFunc,
-    VALUE_AT_QUANTILE_TDIGEST_DOUBLE,
-    value_at_quantile_tdigest_double
-);
+make_udf_function!(value_at_quantile_impl::value_at_quantile_qdigest_doubleFunc, VALUE_AT_QUANTILE_QDIGEST_DOUBLE, value_at_quantile_qdigest_double);
+make_udf_function!(value_at_quantile_impl::value_at_quantile_tdigest_doubleFunc, VALUE_AT_QUANTILE_TDIGEST_DOUBLE, value_at_quantile_tdigest_double);
 
-make_udf_function!(
-    values_at_quantiles_impl::values_at_quantiles_qdigest_array_doubleFunc,
-    VALUES_AT_QUANTILES_QDIGEST_ARRAY_DOUBLE,
-    values_at_quantiles_qdigest_array_double
-);
-make_udf_function!(
-    values_at_quantiles_impl::values_at_quantiles_tdigest_array_doubleFunc,
-    VALUES_AT_QUANTILES_TDIGEST_ARRAY_DOUBLE,
-    values_at_quantiles_tdigest_array_double
-);
+make_udf_function!(values_at_quantiles_impl::values_at_quantiles_qdigest_array_doubleFunc, VALUES_AT_QUANTILES_QDIGEST_ARRAY_DOUBLE, values_at_quantiles_qdigest_array_double);
+make_udf_function!(values_at_quantiles_impl::values_at_quantiles_tdigest_array_doubleFunc, VALUES_AT_QUANTILES_TDIGEST_ARRAY_DOUBLE, values_at_quantiles_tdigest_array_double);
 
 make_udf_function!(week_impl::week_dateFunc, WEEK_DATE, week_date);
-make_udf_function!(
-    week_impl::week_timestamp_pFunc,
-    WEEK_TIMESTAMP_P,
-    week_timestamp_p
-);
+make_udf_function!(week_impl::week_timestamp_pFunc, WEEK_TIMESTAMP_P, week_timestamp_p);
 
-make_udf_function!(
-    week_of_year_impl::week_of_year_dateFunc,
-    WEEK_OF_YEAR_DATE,
-    week_of_year_date
-);
-make_udf_function!(
-    week_of_year_impl::week_of_year_timestamp_pFunc,
-    WEEK_OF_YEAR_TIMESTAMP_P,
-    week_of_year_timestamp_p
-);
+make_udf_function!(week_of_year_impl::week_of_year_dateFunc, WEEK_OF_YEAR_DATE, week_of_year_date);
+make_udf_function!(week_of_year_impl::week_of_year_timestamp_pFunc, WEEK_OF_YEAR_TIMESTAMP_P, week_of_year_timestamp_p);
 
-make_udf_function!(
-    width_bucket_impl::width_bucket_double_array_doubleFunc,
-    WIDTH_BUCKET_DOUBLE_ARRAY_DOUBLE,
-    width_bucket_double_array_double
-);
-make_udf_function!(
-    width_bucket_impl::width_bucket_double_double_double_bigintFunc,
-    WIDTH_BUCKET_DOUBLE_DOUBLE_DOUBLE_BIGINT,
-    width_bucket_double_double_double_bigint
-);
+make_udf_function!(width_bucket_impl::width_bucket_double_array_doubleFunc, WIDTH_BUCKET_DOUBLE_ARRAY_DOUBLE, width_bucket_double_array_double);
+make_udf_function!(width_bucket_impl::width_bucket_double_double_double_bigintFunc, WIDTH_BUCKET_DOUBLE_DOUBLE_DOUBLE_BIGINT, width_bucket_double_double_double_bigint);
 
-make_udf_function!(
-    wilson_interval_lower_impl::wilson_interval_lower_bigint_bigint_doubleFunc,
-    WILSON_INTERVAL_LOWER_BIGINT_BIGINT_DOUBLE,
-    wilson_interval_lower_bigint_bigint_double
-);
+make_udf_function!(wilson_interval_lower_impl::wilson_interval_lower_bigint_bigint_doubleFunc, WILSON_INTERVAL_LOWER_BIGINT_BIGINT_DOUBLE, wilson_interval_lower_bigint_bigint_double);
 
-make_udf_function!(
-    wilson_interval_upper_impl::wilson_interval_upper_bigint_bigint_doubleFunc,
-    WILSON_INTERVAL_UPPER_BIGINT_BIGINT_DOUBLE,
-    wilson_interval_upper_bigint_bigint_double
-);
+make_udf_function!(wilson_interval_upper_impl::wilson_interval_upper_bigint_bigint_doubleFunc, WILSON_INTERVAL_UPPER_BIGINT_BIGINT_DOUBLE, wilson_interval_upper_bigint_bigint_double);
 
-make_udf_function!(
-    with_timezone_impl::with_timezone_timestamp_p_varcharFunc,
-    WITH_TIMEZONE_TIMESTAMP_P_VARCHAR,
-    with_timezone_timestamp_p_varchar
-);
+make_udf_function!(with_timezone_impl::with_timezone_timestamp_p_varcharFunc, WITH_TIMEZONE_TIMESTAMP_P_VARCHAR, with_timezone_timestamp_p_varchar);
 
-make_udf_function!(
-    word_stem_impl::word_stem_varcharFunc,
-    WORD_STEM_VARCHAR,
-    word_stem_varchar
-);
-make_udf_function!(
-    word_stem_impl::word_stem_varchar_varcharFunc,
-    WORD_STEM_VARCHAR_VARCHAR,
-    word_stem_varchar_varchar
-);
+make_udf_function!(word_stem_impl::word_stem_varcharFunc, WORD_STEM_VARCHAR, word_stem_varchar);
+make_udf_function!(word_stem_impl::word_stem_varchar_varcharFunc, WORD_STEM_VARCHAR_VARCHAR, word_stem_varchar_varchar);
 
-make_udf_function!(
-    xxhash64_impl::xxhash64_varbinaryFunc,
-    XXHASH64_VARBINARY,
-    xxhash64_varbinary
-);
+make_udf_function!(xxhash64_impl::xxhash64_varbinaryFunc, XXHASH64_VARBINARY, xxhash64_varbinary);
 
 make_udf_function!(year_impl::year_dateFunc, YEAR_DATE, year_date);
-make_udf_function!(
-    year_impl::year_intervalyeartomonthFunc,
-    YEAR_INTERVALYEARTOMONTH,
-    year_intervalyeartomonth
-);
-make_udf_function!(
-    year_impl::year_timestamp_pFunc,
-    YEAR_TIMESTAMP_P,
-    year_timestamp_p
-);
+make_udf_function!(year_impl::year_intervalyeartomonthFunc, YEAR_INTERVALYEARTOMONTH, year_intervalyeartomonth);
+make_udf_function!(year_impl::year_timestamp_pFunc, YEAR_TIMESTAMP_P, year_timestamp_p);
 
-make_udf_function!(
-    year_of_week_impl::year_of_week_dateFunc,
-    YEAR_OF_WEEK_DATE,
-    year_of_week_date
-);
-make_udf_function!(
-    year_of_week_impl::year_of_week_timestamp_pFunc,
-    YEAR_OF_WEEK_TIMESTAMP_P,
-    year_of_week_timestamp_p
-);
+make_udf_function!(year_of_week_impl::year_of_week_dateFunc, YEAR_OF_WEEK_DATE, year_of_week_date);
+make_udf_function!(year_of_week_impl::year_of_week_timestamp_pFunc, YEAR_OF_WEEK_TIMESTAMP_P, year_of_week_timestamp_p);
 
 make_udf_function!(yow_impl::yow_dateFunc, YOW_DATE, yow_date);
-make_udf_function!(
-    yow_impl::yow_timestamp_pFunc,
-    YOW_TIMESTAMP_P,
-    yow_timestamp_p
-);
+make_udf_function!(yow_impl::yow_timestamp_pFunc, YOW_TIMESTAMP_P, yow_timestamp_p);
 
-make_udf_function!(
-    zip_impl::zip_array_14_array_15Func,
-    ZIP_ARRAY_14_ARRAY_15,
-    zip_array_14_array_15
-);
-make_udf_function!(
-    zip_impl::zip_array_14_array_15_array_16Func,
-    ZIP_ARRAY_14_ARRAY_15_ARRAY_16,
-    zip_array_14_array_15_array_16
-);
-make_udf_function!(
-    zip_impl::zip_array_14_array_15_array_16_array_17Func,
-    ZIP_ARRAY_14_ARRAY_15_ARRAY_16_ARRAY_17,
-    zip_array_14_array_15_array_16_array_17
-);
-make_udf_function!(
-    zip_impl::zip_array_14_array_15_array_16_array_17_array_18Func,
-    ZIP_ARRAY_14_ARRAY_15_ARRAY_16_ARRAY_17_ARRAY_18,
-    zip_array_14_array_15_array_16_array_17_array_18
-);
+make_udf_function!(zip_impl::zip_array_14_array_15Func, ZIP_ARRAY_14_ARRAY_15, zip_array_14_array_15);
+make_udf_function!(zip_impl::zip_array_14_array_15_array_16Func, ZIP_ARRAY_14_ARRAY_15_ARRAY_16, zip_array_14_array_15_array_16);
+make_udf_function!(zip_impl::zip_array_14_array_15_array_16_array_17Func, ZIP_ARRAY_14_ARRAY_15_ARRAY_16_ARRAY_17, zip_array_14_array_15_array_16_array_17);
+make_udf_function!(zip_impl::zip_array_14_array_15_array_16_array_17_array_18Func, ZIP_ARRAY_14_ARRAY_15_ARRAY_16_ARRAY_17_ARRAY_18, zip_array_14_array_15_array_16_array_17_array_18);
 
-make_udf_function!(
-    zip_with_impl::zip_with_array_1_array_11_function_1_11_9Func,
-    ZIP_WITH_ARRAY_1_ARRAY_11_FUNCTION_1_11_9,
-    zip_with_array_1_array_11_function_1_11_9
-);
+make_udf_function!(zip_with_impl::zip_with_array_1_array_11_function_1_11_9Func, ZIP_WITH_ARRAY_1_ARRAY_11_FUNCTION_1_11_9, zip_with_array_1_array_11_function_1_11_9);
+
+
+
 
 // Export the functions out of this package, both as expr_fn as well as a list of functions
 export_functions!(
@@ -3586,7 +1681,6 @@ export_functions!(
 
     (trino, length_varchar, arg1, "function doc"),
     (trino, length_varbinary, arg1, "function doc"),
-    (trino, length_array_1, arg1, "function doc"),
 
     (trino, levenshtein_distance_varchar_varchar, arg1 arg2, "function doc"),
 

--- a/src/trino/mod_impl.rs
+++ b/src/trino/mod_impl.rs
@@ -188,13 +188,14 @@ fn mod_tinyint_tinyint_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct mod_bigint_bigintFunc {
     signature: Signature,
 }
 
 impl mod_bigint_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -213,6 +214,7 @@ impl ScalarUDFImpl for mod_bigint_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         mod_bigint_bigint_return_type(arg_types)
     }
@@ -221,9 +223,14 @@ impl ScalarUDFImpl for mod_bigint_bigintFunc {
         mod_bigint_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         mod_bigint_bigint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -232,7 +239,7 @@ pub(super) struct mod_decimal_a_precision_a_scale_decimal_b_precision_b_scaleFun
 }
 
 impl mod_decimal_a_precision_a_scale_decimal_b_precision_b_scaleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -251,6 +258,7 @@ impl ScalarUDFImpl for mod_decimal_a_precision_a_scale_decimal_b_precision_b_sca
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         mod_decimal_a_precision_a_scale_decimal_b_precision_b_scale_return_type(arg_types)
     }
@@ -259,9 +267,14 @@ impl ScalarUDFImpl for mod_decimal_a_precision_a_scale_decimal_b_precision_b_sca
         mod_decimal_a_precision_a_scale_decimal_b_precision_b_scale_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         mod_decimal_a_precision_a_scale_decimal_b_precision_b_scale_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -270,7 +283,7 @@ pub(super) struct mod_double_doubleFunc {
 }
 
 impl mod_double_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -289,6 +302,7 @@ impl ScalarUDFImpl for mod_double_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         mod_double_double_return_type(arg_types)
     }
@@ -297,9 +311,14 @@ impl ScalarUDFImpl for mod_double_doubleFunc {
         mod_double_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         mod_double_double_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -308,7 +327,7 @@ pub(super) struct mod_integer_integerFunc {
 }
 
 impl mod_integer_integerFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -327,6 +346,7 @@ impl ScalarUDFImpl for mod_integer_integerFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         mod_integer_integer_return_type(arg_types)
     }
@@ -335,9 +355,14 @@ impl ScalarUDFImpl for mod_integer_integerFunc {
         mod_integer_integer_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         mod_integer_integer_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -346,7 +371,7 @@ pub(super) struct mod_real_realFunc {
 }
 
 impl mod_real_realFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -365,6 +390,7 @@ impl ScalarUDFImpl for mod_real_realFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         mod_real_real_return_type(arg_types)
     }
@@ -373,9 +399,14 @@ impl ScalarUDFImpl for mod_real_realFunc {
         mod_real_real_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         mod_real_real_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -384,7 +415,7 @@ pub(super) struct mod_smallint_smallintFunc {
 }
 
 impl mod_smallint_smallintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -403,6 +434,7 @@ impl ScalarUDFImpl for mod_smallint_smallintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         mod_smallint_smallint_return_type(arg_types)
     }
@@ -411,9 +443,14 @@ impl ScalarUDFImpl for mod_smallint_smallintFunc {
         mod_smallint_smallint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         mod_smallint_smallint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -422,7 +459,7 @@ pub(super) struct mod_tinyint_tinyintFunc {
 }
 
 impl mod_tinyint_tinyintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -441,6 +478,7 @@ impl ScalarUDFImpl for mod_tinyint_tinyintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         mod_tinyint_tinyint_return_type(arg_types)
     }
@@ -449,7 +487,12 @@ impl ScalarUDFImpl for mod_tinyint_tinyintFunc {
         mod_tinyint_tinyint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         mod_tinyint_tinyint_simplify(args, info)
     }
+
 }

--- a/src/trino/month_impl.rs
+++ b/src/trino/month_impl.rs
@@ -72,13 +72,14 @@ fn month_timestamp_p_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct month_dateFunc {
     signature: Signature,
 }
 
 impl month_dateFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -97,6 +98,7 @@ impl ScalarUDFImpl for month_dateFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         month_date_return_type(arg_types)
     }
@@ -105,9 +107,14 @@ impl ScalarUDFImpl for month_dateFunc {
         month_date_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         month_date_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -116,7 +123,7 @@ pub(super) struct month_intervalyeartomonthFunc {
 }
 
 impl month_intervalyeartomonthFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -135,6 +142,7 @@ impl ScalarUDFImpl for month_intervalyeartomonthFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         month_intervalyeartomonth_return_type(arg_types)
     }
@@ -143,9 +151,14 @@ impl ScalarUDFImpl for month_intervalyeartomonthFunc {
         month_intervalyeartomonth_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         month_intervalyeartomonth_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -154,7 +167,7 @@ pub(super) struct month_timestamp_pFunc {
 }
 
 impl month_timestamp_pFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -173,6 +186,7 @@ impl ScalarUDFImpl for month_timestamp_pFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         month_timestamp_p_return_type(arg_types)
     }
@@ -181,7 +195,12 @@ impl ScalarUDFImpl for month_timestamp_pFunc {
         month_timestamp_p_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         month_timestamp_p_simplify(args, info)
     }
+
 }

--- a/src/trino/multimap_from_entries_impl.rs
+++ b/src/trino/multimap_from_entries_impl.rs
@@ -54,13 +54,14 @@ fn multimap_from_entries_array_row_c04_c15_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct multimap_from_entries_array_row_c04_c15Func {
     signature: Signature,
 }
 
 impl multimap_from_entries_array_row_c04_c15Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -79,6 +80,7 @@ impl ScalarUDFImpl for multimap_from_entries_array_row_c04_c15Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         multimap_from_entries_array_row_c04_c15_return_type(arg_types)
     }
@@ -87,7 +89,12 @@ impl ScalarUDFImpl for multimap_from_entries_array_row_c04_c15Func {
         multimap_from_entries_array_row_c04_c15_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         multimap_from_entries_array_row_c04_c15_simplify(args, info)
     }
+
 }

--- a/src/trino/murmur3_impl.rs
+++ b/src/trino/murmur3_impl.rs
@@ -50,13 +50,14 @@ fn murmur3_varbinary_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct murmur3_varbinaryFunc {
     signature: Signature,
 }
 
 impl murmur3_varbinaryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for murmur3_varbinaryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         murmur3_varbinary_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for murmur3_varbinaryFunc {
         murmur3_varbinary_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         murmur3_varbinary_simplify(args, info)
     }
+
 }

--- a/src/trino/nan_impl.rs
+++ b/src/trino/nan_impl.rs
@@ -47,13 +47,14 @@ fn nan_simplify(args: Vec<Expr>, _info: &dyn SimplifyInfo) -> Result<ExprSimplif
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct nanFunc {
     signature: Signature,
 }
 
 impl nanFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(0, Volatility::Immutable),
         }
@@ -72,6 +73,7 @@ impl ScalarUDFImpl for nanFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         nan_return_type(arg_types)
     }
@@ -80,7 +82,12 @@ impl ScalarUDFImpl for nanFunc {
         nan_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         nan_simplify(args, info)
     }
+
 }

--- a/src/trino/ngrams_impl.rs
+++ b/src/trino/ngrams_impl.rs
@@ -50,13 +50,14 @@ fn ngrams_array_1_bigint_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct ngrams_array_1_bigintFunc {
     signature: Signature,
 }
 
 impl ngrams_array_1_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for ngrams_array_1_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         ngrams_array_1_bigint_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for ngrams_array_1_bigintFunc {
         ngrams_array_1_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         ngrams_array_1_bigint_simplify(args, info)
     }
+
 }

--- a/src/trino/none_match_impl.rs
+++ b/src/trino/none_match_impl.rs
@@ -50,13 +50,14 @@ fn none_match_array_1_function_1_boolean_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct none_match_array_1_function_1_booleanFunc {
     signature: Signature,
 }
 
 impl none_match_array_1_function_1_booleanFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for none_match_array_1_function_1_booleanFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         none_match_array_1_function_1_boolean_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for none_match_array_1_function_1_booleanFunc {
         none_match_array_1_function_1_boolean_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         none_match_array_1_function_1_boolean_simplify(args, info)
     }
+
 }

--- a/src/trino/normal_cdf_impl.rs
+++ b/src/trino/normal_cdf_impl.rs
@@ -50,13 +50,14 @@ fn normal_cdf_double_double_double_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct normal_cdf_double_double_doubleFunc {
     signature: Signature,
 }
 
 impl normal_cdf_double_double_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(3, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for normal_cdf_double_double_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         normal_cdf_double_double_double_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for normal_cdf_double_double_doubleFunc {
         normal_cdf_double_double_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         normal_cdf_double_double_double_simplify(args, info)
     }
+
 }

--- a/src/trino/normalize_impl.rs
+++ b/src/trino/normalize_impl.rs
@@ -50,13 +50,14 @@ fn normalize_varchar_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct normalize_varchar_varcharFunc {
     signature: Signature,
 }
 
 impl normalize_varchar_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for normalize_varchar_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         normalize_varchar_varchar_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for normalize_varchar_varcharFunc {
         normalize_varchar_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         normalize_varchar_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/now_impl.rs
+++ b/src/trino/now_impl.rs
@@ -47,13 +47,14 @@ fn now_simplify(args: Vec<Expr>, _info: &dyn SimplifyInfo) -> Result<ExprSimplif
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct nowFunc {
     signature: Signature,
 }
 
 impl nowFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(0, Volatility::Immutable),
         }
@@ -72,6 +73,7 @@ impl ScalarUDFImpl for nowFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         now_return_type(arg_types)
     }
@@ -80,7 +82,12 @@ impl ScalarUDFImpl for nowFunc {
         now_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         now_simplify(args, info)
     }
+
 }

--- a/src/trino/nullif_impl.rs
+++ b/src/trino/nullif_impl.rs
@@ -47,13 +47,14 @@ fn nullif_1_1_simplify(args: Vec<Expr>, _info: &dyn SimplifyInfo) -> Result<Expr
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct nullif_1_1Func {
     signature: Signature,
 }
 
 impl nullif_1_1Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -72,6 +73,7 @@ impl ScalarUDFImpl for nullif_1_1Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         nullif_1_1_return_type(arg_types)
     }
@@ -80,7 +82,12 @@ impl ScalarUDFImpl for nullif_1_1Func {
         nullif_1_1_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         nullif_1_1_simplify(args, info)
     }
+
 }

--- a/src/trino/objectid_impl.rs
+++ b/src/trino/objectid_impl.rs
@@ -70,13 +70,14 @@ fn objectid_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct objectidFunc {
     signature: Signature,
 }
 
 impl objectidFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(0, Volatility::Immutable),
         }
@@ -95,6 +96,7 @@ impl ScalarUDFImpl for objectidFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         objectid_return_type(arg_types)
     }
@@ -103,9 +105,14 @@ impl ScalarUDFImpl for objectidFunc {
         objectid_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         objectid_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -114,7 +121,7 @@ pub(super) struct objectid_varcharFunc {
 }
 
 impl objectid_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -133,6 +140,7 @@ impl ScalarUDFImpl for objectid_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         objectid_varchar_return_type(arg_types)
     }
@@ -141,7 +149,12 @@ impl ScalarUDFImpl for objectid_varcharFunc {
         objectid_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         objectid_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/objectid_timestamp_impl.rs
+++ b/src/trino/objectid_timestamp_impl.rs
@@ -50,13 +50,14 @@ fn objectid_timestamp_objectid_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct objectid_timestamp_objectidFunc {
     signature: Signature,
 }
 
 impl objectid_timestamp_objectidFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for objectid_timestamp_objectidFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         objectid_timestamp_objectid_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for objectid_timestamp_objectidFunc {
         objectid_timestamp_objectid_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         objectid_timestamp_objectid_simplify(args, info)
     }
+
 }

--- a/src/trino/parse_data_size_impl.rs
+++ b/src/trino/parse_data_size_impl.rs
@@ -50,13 +50,14 @@ fn parse_data_size_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct parse_data_size_varcharFunc {
     signature: Signature,
 }
 
 impl parse_data_size_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for parse_data_size_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         parse_data_size_varchar_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for parse_data_size_varcharFunc {
         parse_data_size_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         parse_data_size_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/parse_datetime_impl.rs
+++ b/src/trino/parse_datetime_impl.rs
@@ -50,13 +50,14 @@ fn parse_datetime_varchar_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct parse_datetime_varchar_varcharFunc {
     signature: Signature,
 }
 
 impl parse_datetime_varchar_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for parse_datetime_varchar_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         parse_datetime_varchar_varchar_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for parse_datetime_varchar_varcharFunc {
         parse_datetime_varchar_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         parse_datetime_varchar_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/parse_duration_impl.rs
+++ b/src/trino/parse_duration_impl.rs
@@ -50,13 +50,14 @@ fn parse_duration_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct parse_duration_varcharFunc {
     signature: Signature,
 }
 
 impl parse_duration_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for parse_duration_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         parse_duration_varchar_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for parse_duration_varcharFunc {
         parse_duration_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         parse_duration_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/parse_presto_data_size_impl.rs
+++ b/src/trino/parse_presto_data_size_impl.rs
@@ -50,13 +50,14 @@ fn parse_presto_data_size_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct parse_presto_data_size_varcharFunc {
     signature: Signature,
 }
 
 impl parse_presto_data_size_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for parse_presto_data_size_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         parse_presto_data_size_varchar_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for parse_presto_data_size_varcharFunc {
         parse_presto_data_size_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         parse_presto_data_size_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/pi_impl.rs
+++ b/src/trino/pi_impl.rs
@@ -47,13 +47,14 @@ fn pi_simplify(args: Vec<Expr>, _info: &dyn SimplifyInfo) -> Result<ExprSimplify
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct piFunc {
     signature: Signature,
 }
 
 impl piFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(0, Volatility::Immutable),
         }
@@ -72,6 +73,7 @@ impl ScalarUDFImpl for piFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         pi_return_type(arg_types)
     }
@@ -80,7 +82,12 @@ impl ScalarUDFImpl for piFunc {
         pi_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         pi_simplify(args, info)
     }
+
 }

--- a/src/trino/pow_impl.rs
+++ b/src/trino/pow_impl.rs
@@ -50,13 +50,14 @@ fn pow_double_double_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct pow_double_doubleFunc {
     signature: Signature,
 }
 
 impl pow_double_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for pow_double_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         pow_double_double_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for pow_double_doubleFunc {
         pow_double_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         pow_double_double_simplify(args, info)
     }
+
 }

--- a/src/trino/power_impl.rs
+++ b/src/trino/power_impl.rs
@@ -50,13 +50,14 @@ fn power_double_double_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct power_double_doubleFunc {
     signature: Signature,
 }
 
 impl power_double_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for power_double_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         power_double_double_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for power_double_doubleFunc {
         power_double_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         power_double_double_simplify(args, info)
     }
+
 }

--- a/src/trino/quantile_at_value_impl.rs
+++ b/src/trino/quantile_at_value_impl.rs
@@ -96,13 +96,14 @@ fn quantile_at_value_qdigest_real_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct quantile_at_value_qdigest_bigintFunc {
     signature: Signature,
 }
 
 impl quantile_at_value_qdigest_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -121,6 +122,7 @@ impl ScalarUDFImpl for quantile_at_value_qdigest_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         quantile_at_value_qdigest_bigint_return_type(arg_types)
     }
@@ -129,9 +131,14 @@ impl ScalarUDFImpl for quantile_at_value_qdigest_bigintFunc {
         quantile_at_value_qdigest_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         quantile_at_value_qdigest_bigint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -140,7 +147,7 @@ pub(super) struct quantile_at_value_qdigest_doubleFunc {
 }
 
 impl quantile_at_value_qdigest_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -159,6 +166,7 @@ impl ScalarUDFImpl for quantile_at_value_qdigest_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         quantile_at_value_qdigest_double_return_type(arg_types)
     }
@@ -167,9 +175,14 @@ impl ScalarUDFImpl for quantile_at_value_qdigest_doubleFunc {
         quantile_at_value_qdigest_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         quantile_at_value_qdigest_double_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -178,7 +191,7 @@ pub(super) struct quantile_at_value_qdigest_realFunc {
 }
 
 impl quantile_at_value_qdigest_realFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -197,6 +210,7 @@ impl ScalarUDFImpl for quantile_at_value_qdigest_realFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         quantile_at_value_qdigest_real_return_type(arg_types)
     }
@@ -205,7 +219,12 @@ impl ScalarUDFImpl for quantile_at_value_qdigest_realFunc {
         quantile_at_value_qdigest_real_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         quantile_at_value_qdigest_real_simplify(args, info)
     }
+
 }

--- a/src/trino/quarter_impl.rs
+++ b/src/trino/quarter_impl.rs
@@ -56,13 +56,14 @@ fn quarter_timestamp_p_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct quarter_dateFunc {
     signature: Signature,
 }
 
 impl quarter_dateFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -81,6 +82,7 @@ impl ScalarUDFImpl for quarter_dateFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         quarter_date_return_type(arg_types)
     }
@@ -89,9 +91,14 @@ impl ScalarUDFImpl for quarter_dateFunc {
         quarter_date_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         quarter_date_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -100,7 +107,7 @@ pub(super) struct quarter_timestamp_pFunc {
 }
 
 impl quarter_timestamp_pFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -119,6 +126,7 @@ impl ScalarUDFImpl for quarter_timestamp_pFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         quarter_timestamp_p_return_type(arg_types)
     }
@@ -127,7 +135,12 @@ impl ScalarUDFImpl for quarter_timestamp_pFunc {
         quarter_timestamp_p_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         quarter_timestamp_p_simplify(args, info)
     }
+
 }

--- a/src/trino/radians_impl.rs
+++ b/src/trino/radians_impl.rs
@@ -50,13 +50,14 @@ fn radians_double_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct radians_doubleFunc {
     signature: Signature,
 }
 
 impl radians_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for radians_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         radians_double_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for radians_doubleFunc {
         radians_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         radians_double_simplify(args, info)
     }
+
 }

--- a/src/trino/rand_impl.rs
+++ b/src/trino/rand_impl.rs
@@ -219,13 +219,14 @@ fn rand_tinyint_tinyint_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct rand_bigintFunc {
     signature: Signature,
 }
 
 impl rand_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -244,6 +245,7 @@ impl ScalarUDFImpl for rand_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         rand_bigint_return_type(arg_types)
     }
@@ -252,9 +254,14 @@ impl ScalarUDFImpl for rand_bigintFunc {
         rand_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         rand_bigint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -263,7 +270,7 @@ pub(super) struct rand_bigint_bigintFunc {
 }
 
 impl rand_bigint_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -282,6 +289,7 @@ impl ScalarUDFImpl for rand_bigint_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         rand_bigint_bigint_return_type(arg_types)
     }
@@ -290,9 +298,14 @@ impl ScalarUDFImpl for rand_bigint_bigintFunc {
         rand_bigint_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         rand_bigint_bigint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -301,7 +314,7 @@ pub(super) struct randFunc {
 }
 
 impl randFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(0, Volatility::Immutable),
         }
@@ -320,6 +333,7 @@ impl ScalarUDFImpl for randFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         rand_return_type(arg_types)
     }
@@ -328,9 +342,14 @@ impl ScalarUDFImpl for randFunc {
         rand_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         rand_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -339,7 +358,7 @@ pub(super) struct rand_integerFunc {
 }
 
 impl rand_integerFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -358,6 +377,7 @@ impl ScalarUDFImpl for rand_integerFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         rand_integer_return_type(arg_types)
     }
@@ -366,9 +386,14 @@ impl ScalarUDFImpl for rand_integerFunc {
         rand_integer_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         rand_integer_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -377,7 +402,7 @@ pub(super) struct rand_integer_integerFunc {
 }
 
 impl rand_integer_integerFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -396,6 +421,7 @@ impl ScalarUDFImpl for rand_integer_integerFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         rand_integer_integer_return_type(arg_types)
     }
@@ -404,9 +430,14 @@ impl ScalarUDFImpl for rand_integer_integerFunc {
         rand_integer_integer_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         rand_integer_integer_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -415,7 +446,7 @@ pub(super) struct rand_smallintFunc {
 }
 
 impl rand_smallintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -434,6 +465,7 @@ impl ScalarUDFImpl for rand_smallintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         rand_smallint_return_type(arg_types)
     }
@@ -442,9 +474,14 @@ impl ScalarUDFImpl for rand_smallintFunc {
         rand_smallint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         rand_smallint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -453,7 +490,7 @@ pub(super) struct rand_smallint_smallintFunc {
 }
 
 impl rand_smallint_smallintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -472,6 +509,7 @@ impl ScalarUDFImpl for rand_smallint_smallintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         rand_smallint_smallint_return_type(arg_types)
     }
@@ -480,9 +518,14 @@ impl ScalarUDFImpl for rand_smallint_smallintFunc {
         rand_smallint_smallint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         rand_smallint_smallint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -491,7 +534,7 @@ pub(super) struct rand_tinyintFunc {
 }
 
 impl rand_tinyintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -510,6 +553,7 @@ impl ScalarUDFImpl for rand_tinyintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         rand_tinyint_return_type(arg_types)
     }
@@ -518,9 +562,14 @@ impl ScalarUDFImpl for rand_tinyintFunc {
         rand_tinyint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         rand_tinyint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -529,7 +578,7 @@ pub(super) struct rand_tinyint_tinyintFunc {
 }
 
 impl rand_tinyint_tinyintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -548,6 +597,7 @@ impl ScalarUDFImpl for rand_tinyint_tinyintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         rand_tinyint_tinyint_return_type(arg_types)
     }
@@ -556,7 +606,12 @@ impl ScalarUDFImpl for rand_tinyint_tinyintFunc {
         rand_tinyint_tinyint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         rand_tinyint_tinyint_simplify(args, info)
     }
+
 }

--- a/src/trino/random_impl.rs
+++ b/src/trino/random_impl.rs
@@ -228,13 +228,14 @@ fn random_tinyint_tinyint_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct random_bigintFunc {
     signature: Signature,
 }
 
 impl random_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -253,6 +254,7 @@ impl ScalarUDFImpl for random_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         random_bigint_return_type(arg_types)
     }
@@ -261,9 +263,14 @@ impl ScalarUDFImpl for random_bigintFunc {
         random_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         random_bigint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -272,7 +279,7 @@ pub(super) struct random_bigint_bigintFunc {
 }
 
 impl random_bigint_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -291,6 +298,7 @@ impl ScalarUDFImpl for random_bigint_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         random_bigint_bigint_return_type(arg_types)
     }
@@ -299,9 +307,14 @@ impl ScalarUDFImpl for random_bigint_bigintFunc {
         random_bigint_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         random_bigint_bigint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -310,7 +323,7 @@ pub(super) struct randomFunc {
 }
 
 impl randomFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(0, Volatility::Immutable),
         }
@@ -329,6 +342,7 @@ impl ScalarUDFImpl for randomFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         random_return_type(arg_types)
     }
@@ -337,9 +351,14 @@ impl ScalarUDFImpl for randomFunc {
         random_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         random_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -348,7 +367,7 @@ pub(super) struct random_integerFunc {
 }
 
 impl random_integerFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -367,6 +386,7 @@ impl ScalarUDFImpl for random_integerFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         random_integer_return_type(arg_types)
     }
@@ -375,9 +395,14 @@ impl ScalarUDFImpl for random_integerFunc {
         random_integer_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         random_integer_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -386,7 +411,7 @@ pub(super) struct random_integer_integerFunc {
 }
 
 impl random_integer_integerFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -405,6 +430,7 @@ impl ScalarUDFImpl for random_integer_integerFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         random_integer_integer_return_type(arg_types)
     }
@@ -413,9 +439,14 @@ impl ScalarUDFImpl for random_integer_integerFunc {
         random_integer_integer_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         random_integer_integer_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -424,7 +455,7 @@ pub(super) struct random_smallintFunc {
 }
 
 impl random_smallintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -443,6 +474,7 @@ impl ScalarUDFImpl for random_smallintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         random_smallint_return_type(arg_types)
     }
@@ -451,9 +483,14 @@ impl ScalarUDFImpl for random_smallintFunc {
         random_smallint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         random_smallint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -462,7 +499,7 @@ pub(super) struct random_smallint_smallintFunc {
 }
 
 impl random_smallint_smallintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -481,6 +518,7 @@ impl ScalarUDFImpl for random_smallint_smallintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         random_smallint_smallint_return_type(arg_types)
     }
@@ -489,9 +527,14 @@ impl ScalarUDFImpl for random_smallint_smallintFunc {
         random_smallint_smallint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         random_smallint_smallint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -500,7 +543,7 @@ pub(super) struct random_tinyintFunc {
 }
 
 impl random_tinyintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -519,6 +562,7 @@ impl ScalarUDFImpl for random_tinyintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         random_tinyint_return_type(arg_types)
     }
@@ -527,9 +571,14 @@ impl ScalarUDFImpl for random_tinyintFunc {
         random_tinyint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         random_tinyint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -538,7 +587,7 @@ pub(super) struct random_tinyint_tinyintFunc {
 }
 
 impl random_tinyint_tinyintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -557,6 +606,7 @@ impl ScalarUDFImpl for random_tinyint_tinyintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         random_tinyint_tinyint_return_type(arg_types)
     }
@@ -565,7 +615,12 @@ impl ScalarUDFImpl for random_tinyint_tinyintFunc {
         random_tinyint_tinyint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         random_tinyint_tinyint_simplify(args, info)
     }
+
 }

--- a/src/trino/reduce_impl.rs
+++ b/src/trino/reduce_impl.rs
@@ -54,13 +54,14 @@ fn reduce_array_1_10_function_10_1_10_function_10_9_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct reduce_array_1_10_function_10_1_10_function_10_9Func {
     signature: Signature,
 }
 
 impl reduce_array_1_10_function_10_1_10_function_10_9Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(4, Volatility::Immutable),
         }
@@ -79,6 +80,7 @@ impl ScalarUDFImpl for reduce_array_1_10_function_10_1_10_function_10_9Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         reduce_array_1_10_function_10_1_10_function_10_9_return_type(arg_types)
     }
@@ -87,7 +89,12 @@ impl ScalarUDFImpl for reduce_array_1_10_function_10_1_10_function_10_9Func {
         reduce_array_1_10_function_10_1_10_function_10_9_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         reduce_array_1_10_function_10_1_10_function_10_9_simplify(args, info)
     }
+
 }

--- a/src/trino/regexp_count_impl.rs
+++ b/src/trino/regexp_count_impl.rs
@@ -56,13 +56,14 @@ fn regexp_count_varchar_joniregexp_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct regexp_count_varchar_joniregexpFunc {
     signature: Signature,
 }
 
 impl regexp_count_varchar_joniregexpFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -81,6 +82,7 @@ impl ScalarUDFImpl for regexp_count_varchar_joniregexpFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         regexp_count_varchar_joniregexp_return_type(arg_types)
     }
@@ -89,7 +91,12 @@ impl ScalarUDFImpl for regexp_count_varchar_joniregexpFunc {
         regexp_count_varchar_joniregexp_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         regexp_count_varchar_joniregexp_simplify(args, info)
     }
+
 }

--- a/src/trino/regexp_extract_all_impl.rs
+++ b/src/trino/regexp_extract_all_impl.rs
@@ -100,13 +100,14 @@ fn regexp_extract_all_varchar_joniregexp_bigint_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct regexp_extract_all_varchar_joniregexpFunc {
     signature: Signature,
 }
 
 impl regexp_extract_all_varchar_joniregexpFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -125,6 +126,7 @@ impl ScalarUDFImpl for regexp_extract_all_varchar_joniregexpFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         regexp_extract_all_varchar_joniregexp_return_type(arg_types)
     }
@@ -133,9 +135,14 @@ impl ScalarUDFImpl for regexp_extract_all_varchar_joniregexpFunc {
         regexp_extract_all_varchar_joniregexp_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         regexp_extract_all_varchar_joniregexp_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -144,7 +151,7 @@ pub(super) struct regexp_extract_all_varchar_joniregexp_bigintFunc {
 }
 
 impl regexp_extract_all_varchar_joniregexp_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(3, Volatility::Immutable),
         }
@@ -163,6 +170,7 @@ impl ScalarUDFImpl for regexp_extract_all_varchar_joniregexp_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         regexp_extract_all_varchar_joniregexp_bigint_return_type(arg_types)
     }
@@ -171,7 +179,12 @@ impl ScalarUDFImpl for regexp_extract_all_varchar_joniregexp_bigintFunc {
         regexp_extract_all_varchar_joniregexp_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         regexp_extract_all_varchar_joniregexp_bigint_simplify(args, info)
     }
+
 }

--- a/src/trino/regexp_extract_impl.rs
+++ b/src/trino/regexp_extract_impl.rs
@@ -108,13 +108,14 @@ fn regexp_extract_varchar_joniregexp_bigint_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct regexp_extract_varchar_joniregexpFunc {
     signature: Signature,
 }
 
 impl regexp_extract_varchar_joniregexpFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -133,6 +134,7 @@ impl ScalarUDFImpl for regexp_extract_varchar_joniregexpFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         regexp_extract_varchar_joniregexp_return_type(arg_types)
     }
@@ -141,9 +143,14 @@ impl ScalarUDFImpl for regexp_extract_varchar_joniregexpFunc {
         regexp_extract_varchar_joniregexp_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         regexp_extract_varchar_joniregexp_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -152,7 +159,7 @@ pub(super) struct regexp_extract_varchar_joniregexp_bigintFunc {
 }
 
 impl regexp_extract_varchar_joniregexp_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(3, Volatility::Immutable),
         }
@@ -171,6 +178,7 @@ impl ScalarUDFImpl for regexp_extract_varchar_joniregexp_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         regexp_extract_varchar_joniregexp_bigint_return_type(arg_types)
     }
@@ -179,7 +187,12 @@ impl ScalarUDFImpl for regexp_extract_varchar_joniregexp_bigintFunc {
         regexp_extract_varchar_joniregexp_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         regexp_extract_varchar_joniregexp_bigint_simplify(args, info)
     }
+
 }

--- a/src/trino/regexp_like_impl.rs
+++ b/src/trino/regexp_like_impl.rs
@@ -51,13 +51,14 @@ fn regexp_like_varchar_joniregexp_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct regexp_like_varchar_joniregexpFunc {
     signature: Signature,
 }
 
 impl regexp_like_varchar_joniregexpFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -76,6 +77,7 @@ impl ScalarUDFImpl for regexp_like_varchar_joniregexpFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         regexp_like_varchar_joniregexp_return_type(arg_types)
     }
@@ -84,7 +86,12 @@ impl ScalarUDFImpl for regexp_like_varchar_joniregexpFunc {
         regexp_like_varchar_joniregexp_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         regexp_like_varchar_joniregexp_simplify(args, info)
     }
+
 }

--- a/src/trino/regexp_position_impl.rs
+++ b/src/trino/regexp_position_impl.rs
@@ -175,13 +175,14 @@ fn regexp_position_varchar_joniregexp_bigint_bigint_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct regexp_position_varchar_joniregexpFunc {
     signature: Signature,
 }
 
 impl regexp_position_varchar_joniregexpFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -200,6 +201,7 @@ impl ScalarUDFImpl for regexp_position_varchar_joniregexpFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         regexp_position_varchar_joniregexp_return_type(arg_types)
     }
@@ -208,9 +210,14 @@ impl ScalarUDFImpl for regexp_position_varchar_joniregexpFunc {
         regexp_position_varchar_joniregexp_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         regexp_position_varchar_joniregexp_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -219,7 +226,7 @@ pub(super) struct regexp_position_varchar_joniregexp_bigintFunc {
 }
 
 impl regexp_position_varchar_joniregexp_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(3, Volatility::Immutable),
         }
@@ -238,6 +245,7 @@ impl ScalarUDFImpl for regexp_position_varchar_joniregexp_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         regexp_position_varchar_joniregexp_bigint_return_type(arg_types)
     }
@@ -246,9 +254,14 @@ impl ScalarUDFImpl for regexp_position_varchar_joniregexp_bigintFunc {
         regexp_position_varchar_joniregexp_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         regexp_position_varchar_joniregexp_bigint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -257,7 +270,7 @@ pub(super) struct regexp_position_varchar_joniregexp_bigint_bigintFunc {
 }
 
 impl regexp_position_varchar_joniregexp_bigint_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(4, Volatility::Immutable),
         }
@@ -276,6 +289,7 @@ impl ScalarUDFImpl for regexp_position_varchar_joniregexp_bigint_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         regexp_position_varchar_joniregexp_bigint_bigint_return_type(arg_types)
     }
@@ -284,7 +298,12 @@ impl ScalarUDFImpl for regexp_position_varchar_joniregexp_bigint_bigintFunc {
         regexp_position_varchar_joniregexp_bigint_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         regexp_position_varchar_joniregexp_bigint_bigint_simplify(args, info)
     }
+
 }

--- a/src/trino/regexp_replace_impl.rs
+++ b/src/trino/regexp_replace_impl.rs
@@ -111,13 +111,14 @@ fn regexp_replace_varchar_joniregexp_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct regexp_replace_varchar_joniregexp_function_array_varchar_varcharFunc {
     signature: Signature,
 }
 
 impl regexp_replace_varchar_joniregexp_function_array_varchar_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(3, Volatility::Immutable),
         }
@@ -136,6 +137,7 @@ impl ScalarUDFImpl for regexp_replace_varchar_joniregexp_function_array_varchar_
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         regexp_replace_varchar_joniregexp_function_array_varchar_varchar_return_type(arg_types)
     }
@@ -144,9 +146,14 @@ impl ScalarUDFImpl for regexp_replace_varchar_joniregexp_function_array_varchar_
         regexp_replace_varchar_joniregexp_function_array_varchar_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         regexp_replace_varchar_joniregexp_function_array_varchar_varchar_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -155,7 +162,7 @@ pub(super) struct regexp_replace_varchar_joniregexpFunc {
 }
 
 impl regexp_replace_varchar_joniregexpFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -174,6 +181,7 @@ impl ScalarUDFImpl for regexp_replace_varchar_joniregexpFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         regexp_replace_varchar_joniregexp_return_type(arg_types)
     }
@@ -182,9 +190,14 @@ impl ScalarUDFImpl for regexp_replace_varchar_joniregexpFunc {
         regexp_replace_varchar_joniregexp_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         regexp_replace_varchar_joniregexp_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -193,7 +206,7 @@ pub(super) struct regexp_replace_varchar_joniregexp_varcharFunc {
 }
 
 impl regexp_replace_varchar_joniregexp_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(3, Volatility::Immutable),
         }
@@ -212,6 +225,7 @@ impl ScalarUDFImpl for regexp_replace_varchar_joniregexp_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         regexp_replace_varchar_joniregexp_varchar_return_type(arg_types)
     }
@@ -220,7 +234,12 @@ impl ScalarUDFImpl for regexp_replace_varchar_joniregexp_varcharFunc {
         regexp_replace_varchar_joniregexp_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         regexp_replace_varchar_joniregexp_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/regexp_split_impl.rs
+++ b/src/trino/regexp_split_impl.rs
@@ -59,13 +59,14 @@ fn regexp_split_varchar_joniregexp_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct regexp_split_varchar_joniregexpFunc {
     signature: Signature,
 }
 
 impl regexp_split_varchar_joniregexpFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -84,6 +85,7 @@ impl ScalarUDFImpl for regexp_split_varchar_joniregexpFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         regexp_split_varchar_joniregexp_return_type(arg_types)
     }
@@ -92,7 +94,12 @@ impl ScalarUDFImpl for regexp_split_varchar_joniregexpFunc {
         regexp_split_varchar_joniregexp_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         regexp_split_varchar_joniregexp_simplify(args, info)
     }
+
 }

--- a/src/trino/regress_impl.rs
+++ b/src/trino/regress_impl.rs
@@ -50,13 +50,14 @@ fn regress_map_bigint_double_regressor_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct regress_map_bigint_double_regressorFunc {
     signature: Signature,
 }
 
 impl regress_map_bigint_double_regressorFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for regress_map_bigint_double_regressorFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         regress_map_bigint_double_regressor_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for regress_map_bigint_double_regressorFunc {
         regress_map_bigint_double_regressor_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         regress_map_bigint_double_regressor_simplify(args, info)
     }
+
 }

--- a/src/trino/render_impl.rs
+++ b/src/trino/render_impl.rs
@@ -119,13 +119,14 @@ fn render_varchar_color_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct render_booleanFunc {
     signature: Signature,
 }
 
 impl render_booleanFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -144,6 +145,7 @@ impl ScalarUDFImpl for render_booleanFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         render_boolean_return_type(arg_types)
     }
@@ -152,9 +154,14 @@ impl ScalarUDFImpl for render_booleanFunc {
         render_boolean_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         render_boolean_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -163,7 +170,7 @@ pub(super) struct render_bigint_colorFunc {
 }
 
 impl render_bigint_colorFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -182,6 +189,7 @@ impl ScalarUDFImpl for render_bigint_colorFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         render_bigint_color_return_type(arg_types)
     }
@@ -190,9 +198,14 @@ impl ScalarUDFImpl for render_bigint_colorFunc {
         render_bigint_color_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         render_bigint_color_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -201,7 +214,7 @@ pub(super) struct render_double_colorFunc {
 }
 
 impl render_double_colorFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -220,6 +233,7 @@ impl ScalarUDFImpl for render_double_colorFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         render_double_color_return_type(arg_types)
     }
@@ -228,9 +242,14 @@ impl ScalarUDFImpl for render_double_colorFunc {
         render_double_color_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         render_double_color_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -239,7 +258,7 @@ pub(super) struct render_varchar_colorFunc {
 }
 
 impl render_varchar_colorFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -258,6 +277,7 @@ impl ScalarUDFImpl for render_varchar_colorFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         render_varchar_color_return_type(arg_types)
     }
@@ -266,7 +286,12 @@ impl ScalarUDFImpl for render_varchar_colorFunc {
         render_varchar_color_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         render_varchar_color_simplify(args, info)
     }
+
 }

--- a/src/trino/repeat_impl.rs
+++ b/src/trino/repeat_impl.rs
@@ -50,13 +50,14 @@ fn repeat_1_bigint_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct repeat_1_bigintFunc {
     signature: Signature,
 }
 
 impl repeat_1_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for repeat_1_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         repeat_1_bigint_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for repeat_1_bigintFunc {
         repeat_1_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         repeat_1_bigint_simplify(args, info)
     }
+
 }

--- a/src/trino/replace_impl.rs
+++ b/src/trino/replace_impl.rs
@@ -73,13 +73,14 @@ fn replace_varchar_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct replace_varchar_varchar_varcharFunc {
     signature: Signature,
 }
 
 impl replace_varchar_varchar_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(3, Volatility::Immutable),
         }
@@ -98,6 +99,7 @@ impl ScalarUDFImpl for replace_varchar_varchar_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         replace_varchar_varchar_varchar_return_type(arg_types)
     }
@@ -106,9 +108,14 @@ impl ScalarUDFImpl for replace_varchar_varchar_varcharFunc {
         replace_varchar_varchar_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         replace_varchar_varchar_varchar_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -117,7 +124,7 @@ pub(super) struct replace_varchar_varcharFunc {
 }
 
 impl replace_varchar_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -136,6 +143,7 @@ impl ScalarUDFImpl for replace_varchar_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         replace_varchar_varchar_return_type(arg_types)
     }
@@ -144,7 +152,12 @@ impl ScalarUDFImpl for replace_varchar_varcharFunc {
         replace_varchar_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         replace_varchar_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/reverse_impl.rs
+++ b/src/trino/reverse_impl.rs
@@ -96,13 +96,14 @@ fn reverse_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct reverse_array_3Func {
     signature: Signature,
 }
 
 impl reverse_array_3Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -121,6 +122,7 @@ impl ScalarUDFImpl for reverse_array_3Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         reverse_array_3_return_type(arg_types)
     }
@@ -129,9 +131,14 @@ impl ScalarUDFImpl for reverse_array_3Func {
         reverse_array_3_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         reverse_array_3_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -140,7 +147,7 @@ pub(super) struct reverse_varbinaryFunc {
 }
 
 impl reverse_varbinaryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -159,6 +166,7 @@ impl ScalarUDFImpl for reverse_varbinaryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         reverse_varbinary_return_type(arg_types)
     }
@@ -167,9 +175,14 @@ impl ScalarUDFImpl for reverse_varbinaryFunc {
         reverse_varbinary_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         reverse_varbinary_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -178,7 +191,7 @@ pub(super) struct reverse_varcharFunc {
 }
 
 impl reverse_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -197,6 +210,7 @@ impl ScalarUDFImpl for reverse_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         reverse_varchar_return_type(arg_types)
     }
@@ -205,7 +219,12 @@ impl ScalarUDFImpl for reverse_varcharFunc {
         reverse_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         reverse_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/rgb_impl.rs
+++ b/src/trino/rgb_impl.rs
@@ -50,13 +50,14 @@ fn rgb_bigint_bigint_bigint_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct rgb_bigint_bigint_bigintFunc {
     signature: Signature,
 }
 
 impl rgb_bigint_bigint_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(3, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for rgb_bigint_bigint_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         rgb_bigint_bigint_bigint_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for rgb_bigint_bigint_bigintFunc {
         rgb_bigint_bigint_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         rgb_bigint_bigint_bigint_simplify(args, info)
     }
+
 }

--- a/src/trino/round_impl.rs
+++ b/src/trino/round_impl.rs
@@ -334,13 +334,14 @@ fn round_tinyint_bigint_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct round_doubleFunc {
     signature: Signature,
 }
 
 impl round_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -359,6 +360,7 @@ impl ScalarUDFImpl for round_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         round_double_return_type(arg_types)
     }
@@ -367,9 +369,14 @@ impl ScalarUDFImpl for round_doubleFunc {
         round_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         round_double_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -378,7 +385,7 @@ pub(super) struct round_double_bigintFunc {
 }
 
 impl round_double_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -397,6 +404,7 @@ impl ScalarUDFImpl for round_double_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         round_double_bigint_return_type(arg_types)
     }
@@ -405,9 +413,14 @@ impl ScalarUDFImpl for round_double_bigintFunc {
         round_double_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         round_double_bigint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -416,7 +429,7 @@ pub(super) struct round_realFunc {
 }
 
 impl round_realFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -435,6 +448,7 @@ impl ScalarUDFImpl for round_realFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         round_real_return_type(arg_types)
     }
@@ -443,9 +457,14 @@ impl ScalarUDFImpl for round_realFunc {
         round_real_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         round_real_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -454,7 +473,7 @@ pub(super) struct round_real_bigintFunc {
 }
 
 impl round_real_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -473,6 +492,7 @@ impl ScalarUDFImpl for round_real_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         round_real_bigint_return_type(arg_types)
     }
@@ -481,9 +501,14 @@ impl ScalarUDFImpl for round_real_bigintFunc {
         round_real_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         round_real_bigint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -492,7 +517,7 @@ pub(super) struct round_integerFunc {
 }
 
 impl round_integerFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -511,6 +536,7 @@ impl ScalarUDFImpl for round_integerFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         round_integer_return_type(arg_types)
     }
@@ -519,9 +545,14 @@ impl ScalarUDFImpl for round_integerFunc {
         round_integer_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         round_integer_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -530,7 +561,7 @@ pub(super) struct round_integer_integerFunc {
 }
 
 impl round_integer_integerFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -549,6 +580,7 @@ impl ScalarUDFImpl for round_integer_integerFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         round_integer_integer_return_type(arg_types)
     }
@@ -557,9 +589,14 @@ impl ScalarUDFImpl for round_integer_integerFunc {
         round_integer_integer_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         round_integer_integer_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -568,7 +605,7 @@ pub(super) struct round_decimal_p_sFunc {
 }
 
 impl round_decimal_p_sFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -587,6 +624,7 @@ impl ScalarUDFImpl for round_decimal_p_sFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         round_decimal_p_s_return_type(arg_types)
     }
@@ -595,9 +633,14 @@ impl ScalarUDFImpl for round_decimal_p_sFunc {
         round_decimal_p_s_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         round_decimal_p_s_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -606,7 +649,7 @@ pub(super) struct round_decimal_p_s_bigintFunc {
 }
 
 impl round_decimal_p_s_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -625,6 +668,7 @@ impl ScalarUDFImpl for round_decimal_p_s_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         round_decimal_p_s_bigint_return_type(arg_types)
     }
@@ -633,9 +677,14 @@ impl ScalarUDFImpl for round_decimal_p_s_bigintFunc {
         round_decimal_p_s_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         round_decimal_p_s_bigint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -644,7 +693,7 @@ pub(super) struct round_bigintFunc {
 }
 
 impl round_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -663,6 +712,7 @@ impl ScalarUDFImpl for round_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         round_bigint_return_type(arg_types)
     }
@@ -671,9 +721,14 @@ impl ScalarUDFImpl for round_bigintFunc {
         round_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         round_bigint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -682,7 +737,7 @@ pub(super) struct round_bigint_bigintFunc {
 }
 
 impl round_bigint_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -701,6 +756,7 @@ impl ScalarUDFImpl for round_bigint_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         round_bigint_bigint_return_type(arg_types)
     }
@@ -709,9 +765,14 @@ impl ScalarUDFImpl for round_bigint_bigintFunc {
         round_bigint_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         round_bigint_bigint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -720,7 +781,7 @@ pub(super) struct round_smallintFunc {
 }
 
 impl round_smallintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -739,6 +800,7 @@ impl ScalarUDFImpl for round_smallintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         round_smallint_return_type(arg_types)
     }
@@ -747,9 +809,14 @@ impl ScalarUDFImpl for round_smallintFunc {
         round_smallint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         round_smallint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -758,7 +825,7 @@ pub(super) struct round_smallint_bigintFunc {
 }
 
 impl round_smallint_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -777,6 +844,7 @@ impl ScalarUDFImpl for round_smallint_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         round_smallint_bigint_return_type(arg_types)
     }
@@ -785,9 +853,14 @@ impl ScalarUDFImpl for round_smallint_bigintFunc {
         round_smallint_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         round_smallint_bigint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -796,7 +869,7 @@ pub(super) struct round_tinyintFunc {
 }
 
 impl round_tinyintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -815,6 +888,7 @@ impl ScalarUDFImpl for round_tinyintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         round_tinyint_return_type(arg_types)
     }
@@ -823,9 +897,14 @@ impl ScalarUDFImpl for round_tinyintFunc {
         round_tinyint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         round_tinyint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -834,7 +913,7 @@ pub(super) struct round_tinyint_bigintFunc {
 }
 
 impl round_tinyint_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -853,6 +932,7 @@ impl ScalarUDFImpl for round_tinyint_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         round_tinyint_bigint_return_type(arg_types)
     }
@@ -861,7 +941,12 @@ impl ScalarUDFImpl for round_tinyint_bigintFunc {
         round_tinyint_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         round_tinyint_bigint_simplify(args, info)
     }
+
 }

--- a/src/trino/rpad_impl.rs
+++ b/src/trino/rpad_impl.rs
@@ -73,13 +73,14 @@ fn rpad_varchar_bigint_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct rpad_varbinary_bigint_varbinaryFunc {
     signature: Signature,
 }
 
 impl rpad_varbinary_bigint_varbinaryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(3, Volatility::Immutable),
         }
@@ -98,6 +99,7 @@ impl ScalarUDFImpl for rpad_varbinary_bigint_varbinaryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         rpad_varbinary_bigint_varbinary_return_type(arg_types)
     }
@@ -106,9 +108,14 @@ impl ScalarUDFImpl for rpad_varbinary_bigint_varbinaryFunc {
         rpad_varbinary_bigint_varbinary_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         rpad_varbinary_bigint_varbinary_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -117,7 +124,7 @@ pub(super) struct rpad_varchar_bigint_varcharFunc {
 }
 
 impl rpad_varchar_bigint_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(3, Volatility::Immutable),
         }
@@ -136,6 +143,7 @@ impl ScalarUDFImpl for rpad_varchar_bigint_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         rpad_varchar_bigint_varchar_return_type(arg_types)
     }
@@ -144,7 +152,12 @@ impl ScalarUDFImpl for rpad_varchar_bigint_varcharFunc {
         rpad_varchar_bigint_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         rpad_varchar_bigint_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/rtrim_impl.rs
+++ b/src/trino/rtrim_impl.rs
@@ -70,13 +70,14 @@ fn rtrim_varchar_codepoints_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct rtrim_varcharFunc {
     signature: Signature,
 }
 
 impl rtrim_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -95,6 +96,7 @@ impl ScalarUDFImpl for rtrim_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         rtrim_varchar_return_type(arg_types)
     }
@@ -103,9 +105,14 @@ impl ScalarUDFImpl for rtrim_varcharFunc {
         rtrim_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         rtrim_varchar_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -114,7 +121,7 @@ pub(super) struct rtrim_varchar_codepointsFunc {
 }
 
 impl rtrim_varchar_codepointsFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -133,6 +140,7 @@ impl ScalarUDFImpl for rtrim_varchar_codepointsFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         rtrim_varchar_codepoints_return_type(arg_types)
     }
@@ -141,7 +149,12 @@ impl ScalarUDFImpl for rtrim_varchar_codepointsFunc {
         rtrim_varchar_codepoints_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         rtrim_varchar_codepoints_simplify(args, info)
     }
+
 }

--- a/src/trino/second_impl.rs
+++ b/src/trino/second_impl.rs
@@ -80,13 +80,14 @@ fn second_timestamp_p_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct second_intervaldaytosecondFunc {
     signature: Signature,
 }
 
 impl second_intervaldaytosecondFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -105,6 +106,7 @@ impl ScalarUDFImpl for second_intervaldaytosecondFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         second_intervaldaytosecond_return_type(arg_types)
     }
@@ -113,9 +115,14 @@ impl ScalarUDFImpl for second_intervaldaytosecondFunc {
         second_intervaldaytosecond_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         second_intervaldaytosecond_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -124,7 +131,7 @@ pub(super) struct second_time_pFunc {
 }
 
 impl second_time_pFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -143,6 +150,7 @@ impl ScalarUDFImpl for second_time_pFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         second_time_p_return_type(arg_types)
     }
@@ -151,9 +159,14 @@ impl ScalarUDFImpl for second_time_pFunc {
         second_time_p_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         second_time_p_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -162,7 +175,7 @@ pub(super) struct second_timestamp_pFunc {
 }
 
 impl second_timestamp_pFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -181,6 +194,7 @@ impl ScalarUDFImpl for second_timestamp_pFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         second_timestamp_p_return_type(arg_types)
     }
@@ -189,7 +203,12 @@ impl ScalarUDFImpl for second_timestamp_pFunc {
         second_timestamp_p_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         second_timestamp_p_simplify(args, info)
     }
+
 }

--- a/src/trino/sequence_impl.rs
+++ b/src/trino/sequence_impl.rs
@@ -169,13 +169,14 @@ fn sequence_timestamp_p_timestamp_p_intervaldaytosecond_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct sequence_bigint_bigintFunc {
     signature: Signature,
 }
 
 impl sequence_bigint_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -194,6 +195,7 @@ impl ScalarUDFImpl for sequence_bigint_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         sequence_bigint_bigint_return_type(arg_types)
     }
@@ -202,9 +204,14 @@ impl ScalarUDFImpl for sequence_bigint_bigintFunc {
         sequence_bigint_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         sequence_bigint_bigint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -213,7 +220,7 @@ pub(super) struct sequence_bigint_bigint_bigintFunc {
 }
 
 impl sequence_bigint_bigint_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(3, Volatility::Immutable),
         }
@@ -232,6 +239,7 @@ impl ScalarUDFImpl for sequence_bigint_bigint_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         sequence_bigint_bigint_bigint_return_type(arg_types)
     }
@@ -240,9 +248,14 @@ impl ScalarUDFImpl for sequence_bigint_bigint_bigintFunc {
         sequence_bigint_bigint_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         sequence_bigint_bigint_bigint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -251,7 +264,7 @@ pub(super) struct sequence_date_dateFunc {
 }
 
 impl sequence_date_dateFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -270,6 +283,7 @@ impl ScalarUDFImpl for sequence_date_dateFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         sequence_date_date_return_type(arg_types)
     }
@@ -278,9 +292,14 @@ impl ScalarUDFImpl for sequence_date_dateFunc {
         sequence_date_date_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         sequence_date_date_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -289,7 +308,7 @@ pub(super) struct sequence_date_date_intervaldaytosecondFunc {
 }
 
 impl sequence_date_date_intervaldaytosecondFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(3, Volatility::Immutable),
         }
@@ -308,6 +327,7 @@ impl ScalarUDFImpl for sequence_date_date_intervaldaytosecondFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         sequence_date_date_intervaldaytosecond_return_type(arg_types)
     }
@@ -316,9 +336,14 @@ impl ScalarUDFImpl for sequence_date_date_intervaldaytosecondFunc {
         sequence_date_date_intervaldaytosecond_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         sequence_date_date_intervaldaytosecond_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -327,7 +352,7 @@ pub(super) struct sequence_date_date_intervalyeartomonthFunc {
 }
 
 impl sequence_date_date_intervalyeartomonthFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(3, Volatility::Immutable),
         }
@@ -346,6 +371,7 @@ impl ScalarUDFImpl for sequence_date_date_intervalyeartomonthFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         sequence_date_date_intervalyeartomonth_return_type(arg_types)
     }
@@ -354,9 +380,14 @@ impl ScalarUDFImpl for sequence_date_date_intervalyeartomonthFunc {
         sequence_date_date_intervalyeartomonth_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         sequence_date_date_intervalyeartomonth_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -365,7 +396,7 @@ pub(super) struct sequence_timestamp_p_timestamp_p_intervaldaytosecondFunc {
 }
 
 impl sequence_timestamp_p_timestamp_p_intervaldaytosecondFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(3, Volatility::Immutable),
         }
@@ -384,6 +415,7 @@ impl ScalarUDFImpl for sequence_timestamp_p_timestamp_p_intervaldaytosecondFunc 
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         sequence_timestamp_p_timestamp_p_intervaldaytosecond_return_type(arg_types)
     }
@@ -392,7 +424,12 @@ impl ScalarUDFImpl for sequence_timestamp_p_timestamp_p_intervaldaytosecondFunc 
         sequence_timestamp_p_timestamp_p_intervaldaytosecond_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         sequence_timestamp_p_timestamp_p_intervaldaytosecond_simplify(args, info)
     }
+
 }

--- a/src/trino/sha1_impl.rs
+++ b/src/trino/sha1_impl.rs
@@ -50,13 +50,14 @@ fn sha1_varbinary_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct sha1_varbinaryFunc {
     signature: Signature,
 }
 
 impl sha1_varbinaryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for sha1_varbinaryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         sha1_varbinary_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for sha1_varbinaryFunc {
         sha1_varbinary_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         sha1_varbinary_simplify(args, info)
     }
+
 }

--- a/src/trino/sha256_impl.rs
+++ b/src/trino/sha256_impl.rs
@@ -50,13 +50,14 @@ fn sha256_varbinary_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct sha256_varbinaryFunc {
     signature: Signature,
 }
 
 impl sha256_varbinaryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for sha256_varbinaryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         sha256_varbinary_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for sha256_varbinaryFunc {
         sha256_varbinary_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         sha256_varbinary_simplify(args, info)
     }
+
 }

--- a/src/trino/sha512_impl.rs
+++ b/src/trino/sha512_impl.rs
@@ -50,13 +50,14 @@ fn sha512_varbinary_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct sha512_varbinaryFunc {
     signature: Signature,
 }
 
 impl sha512_varbinaryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for sha512_varbinaryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         sha512_varbinary_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for sha512_varbinaryFunc {
         sha512_varbinary_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         sha512_varbinary_simplify(args, info)
     }
+
 }

--- a/src/trino/shuffle_impl.rs
+++ b/src/trino/shuffle_impl.rs
@@ -50,13 +50,14 @@ fn shuffle_array_3_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct shuffle_array_3Func {
     signature: Signature,
 }
 
 impl shuffle_array_3Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for shuffle_array_3Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         shuffle_array_3_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for shuffle_array_3Func {
         shuffle_array_3_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         shuffle_array_3_simplify(args, info)
     }
+
 }

--- a/src/trino/sign_impl.rs
+++ b/src/trino/sign_impl.rs
@@ -182,13 +182,14 @@ fn sign_tinyint_simplify(args: Vec<Expr>, _info: &dyn SimplifyInfo) -> Result<Ex
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct sign_bigintFunc {
     signature: Signature,
 }
 
 impl sign_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -207,6 +208,7 @@ impl ScalarUDFImpl for sign_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         sign_bigint_return_type(arg_types)
     }
@@ -215,9 +217,14 @@ impl ScalarUDFImpl for sign_bigintFunc {
         sign_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         sign_bigint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -226,7 +233,7 @@ pub(super) struct sign_decimal_p_sFunc {
 }
 
 impl sign_decimal_p_sFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -245,6 +252,7 @@ impl ScalarUDFImpl for sign_decimal_p_sFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         sign_decimal_p_s_return_type(arg_types)
     }
@@ -253,9 +261,14 @@ impl ScalarUDFImpl for sign_decimal_p_sFunc {
         sign_decimal_p_s_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         sign_decimal_p_s_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -264,7 +277,7 @@ pub(super) struct sign_doubleFunc {
 }
 
 impl sign_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -283,6 +296,7 @@ impl ScalarUDFImpl for sign_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         sign_double_return_type(arg_types)
     }
@@ -291,9 +305,14 @@ impl ScalarUDFImpl for sign_doubleFunc {
         sign_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         sign_double_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -302,7 +321,7 @@ pub(super) struct sign_integerFunc {
 }
 
 impl sign_integerFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -321,6 +340,7 @@ impl ScalarUDFImpl for sign_integerFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         sign_integer_return_type(arg_types)
     }
@@ -329,9 +349,14 @@ impl ScalarUDFImpl for sign_integerFunc {
         sign_integer_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         sign_integer_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -340,7 +365,7 @@ pub(super) struct sign_realFunc {
 }
 
 impl sign_realFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -359,6 +384,7 @@ impl ScalarUDFImpl for sign_realFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         sign_real_return_type(arg_types)
     }
@@ -367,9 +393,14 @@ impl ScalarUDFImpl for sign_realFunc {
         sign_real_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         sign_real_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -378,7 +409,7 @@ pub(super) struct sign_smallintFunc {
 }
 
 impl sign_smallintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -397,6 +428,7 @@ impl ScalarUDFImpl for sign_smallintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         sign_smallint_return_type(arg_types)
     }
@@ -405,9 +437,14 @@ impl ScalarUDFImpl for sign_smallintFunc {
         sign_smallint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         sign_smallint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -416,7 +453,7 @@ pub(super) struct sign_tinyintFunc {
 }
 
 impl sign_tinyintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -435,6 +472,7 @@ impl ScalarUDFImpl for sign_tinyintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         sign_tinyint_return_type(arg_types)
     }
@@ -443,7 +481,12 @@ impl ScalarUDFImpl for sign_tinyintFunc {
         sign_tinyint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         sign_tinyint_simplify(args, info)
     }
+
 }

--- a/src/trino/simplify_geometry_impl.rs
+++ b/src/trino/simplify_geometry_impl.rs
@@ -50,13 +50,14 @@ fn simplify_geometry_geometry_double_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct simplify_geometry_geometry_doubleFunc {
     signature: Signature,
 }
 
 impl simplify_geometry_geometry_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for simplify_geometry_geometry_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         simplify_geometry_geometry_double_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for simplify_geometry_geometry_doubleFunc {
         simplify_geometry_geometry_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         simplify_geometry_geometry_double_simplify(args, info)
     }
+
 }

--- a/src/trino/sin_impl.rs
+++ b/src/trino/sin_impl.rs
@@ -47,13 +47,14 @@ fn sin_double_simplify(args: Vec<Expr>, _info: &dyn SimplifyInfo) -> Result<Expr
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct sin_doubleFunc {
     signature: Signature,
 }
 
 impl sin_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -72,6 +73,7 @@ impl ScalarUDFImpl for sin_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         sin_double_return_type(arg_types)
     }
@@ -80,7 +82,12 @@ impl ScalarUDFImpl for sin_doubleFunc {
         sin_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         sin_double_simplify(args, info)
     }
+
 }

--- a/src/trino/sinh_impl.rs
+++ b/src/trino/sinh_impl.rs
@@ -47,13 +47,14 @@ fn sinh_double_simplify(args: Vec<Expr>, _info: &dyn SimplifyInfo) -> Result<Exp
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct sinh_doubleFunc {
     signature: Signature,
 }
 
 impl sinh_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -72,6 +73,7 @@ impl ScalarUDFImpl for sinh_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         sinh_double_return_type(arg_types)
     }
@@ -80,7 +82,12 @@ impl ScalarUDFImpl for sinh_doubleFunc {
         sinh_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         sinh_double_simplify(args, info)
     }
+
 }

--- a/src/trino/slice_impl.rs
+++ b/src/trino/slice_impl.rs
@@ -50,13 +50,14 @@ fn slice_array_3_bigint_bigint_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct slice_array_3_bigint_bigintFunc {
     signature: Signature,
 }
 
 impl slice_array_3_bigint_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(3, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for slice_array_3_bigint_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         slice_array_3_bigint_bigint_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for slice_array_3_bigint_bigintFunc {
         slice_array_3_bigint_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         slice_array_3_bigint_bigint_simplify(args, info)
     }
+
 }

--- a/src/trino/soundex_impl.rs
+++ b/src/trino/soundex_impl.rs
@@ -50,13 +50,14 @@ fn soundex_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct soundex_varcharFunc {
     signature: Signature,
 }
 
 impl soundex_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for soundex_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         soundex_varchar_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for soundex_varcharFunc {
         soundex_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         soundex_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/spatial_partitions_impl.rs
+++ b/src/trino/spatial_partitions_impl.rs
@@ -77,13 +77,14 @@ fn spatial_partitions_kdbtree_geometry_double_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct spatial_partitions_kdbtree_geometryFunc {
     signature: Signature,
 }
 
 impl spatial_partitions_kdbtree_geometryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -102,6 +103,7 @@ impl ScalarUDFImpl for spatial_partitions_kdbtree_geometryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         spatial_partitions_kdbtree_geometry_return_type(arg_types)
     }
@@ -110,9 +112,14 @@ impl ScalarUDFImpl for spatial_partitions_kdbtree_geometryFunc {
         spatial_partitions_kdbtree_geometry_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         spatial_partitions_kdbtree_geometry_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -121,7 +128,7 @@ pub(super) struct spatial_partitions_kdbtree_geometry_doubleFunc {
 }
 
 impl spatial_partitions_kdbtree_geometry_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(3, Volatility::Immutable),
         }
@@ -140,6 +147,7 @@ impl ScalarUDFImpl for spatial_partitions_kdbtree_geometry_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         spatial_partitions_kdbtree_geometry_double_return_type(arg_types)
     }
@@ -148,7 +156,12 @@ impl ScalarUDFImpl for spatial_partitions_kdbtree_geometry_doubleFunc {
         spatial_partitions_kdbtree_geometry_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         spatial_partitions_kdbtree_geometry_double_simplify(args, info)
     }
+
 }

--- a/src/trino/split_impl.rs
+++ b/src/trino/split_impl.rs
@@ -103,13 +103,14 @@ fn split_varchar_varchar_bigint_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct split_varchar_varcharFunc {
     signature: Signature,
 }
 
 impl split_varchar_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -128,6 +129,7 @@ impl ScalarUDFImpl for split_varchar_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         split_varchar_varchar_return_type(arg_types)
     }
@@ -136,9 +138,14 @@ impl ScalarUDFImpl for split_varchar_varcharFunc {
         split_varchar_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         split_varchar_varchar_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -147,7 +154,7 @@ pub(super) struct split_varchar_varchar_bigintFunc {
 }
 
 impl split_varchar_varchar_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(3, Volatility::Immutable),
         }
@@ -166,6 +173,7 @@ impl ScalarUDFImpl for split_varchar_varchar_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         split_varchar_varchar_bigint_return_type(arg_types)
     }
@@ -174,7 +182,12 @@ impl ScalarUDFImpl for split_varchar_varchar_bigintFunc {
         split_varchar_varchar_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         split_varchar_varchar_bigint_simplify(args, info)
     }
+
 }

--- a/src/trino/split_part_impl.rs
+++ b/src/trino/split_part_impl.rs
@@ -50,13 +50,14 @@ fn split_part_varchar_varchar_bigint_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct split_part_varchar_varchar_bigintFunc {
     signature: Signature,
 }
 
 impl split_part_varchar_varchar_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(3, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for split_part_varchar_varchar_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         split_part_varchar_varchar_bigint_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for split_part_varchar_varchar_bigintFunc {
         split_part_varchar_varchar_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         split_part_varchar_varchar_bigint_simplify(args, info)
     }
+
 }

--- a/src/trino/split_to_map_impl.rs
+++ b/src/trino/split_to_map_impl.rs
@@ -50,13 +50,14 @@ fn split_to_map_varchar_varchar_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct split_to_map_varchar_varchar_varcharFunc {
     signature: Signature,
 }
 
 impl split_to_map_varchar_varchar_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(3, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for split_to_map_varchar_varchar_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         split_to_map_varchar_varchar_varchar_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for split_to_map_varchar_varchar_varcharFunc {
         split_to_map_varchar_varchar_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         split_to_map_varchar_varchar_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/split_to_multimap_impl.rs
+++ b/src/trino/split_to_multimap_impl.rs
@@ -54,13 +54,14 @@ fn split_to_multimap_varchar_varchar_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct split_to_multimap_varchar_varchar_varcharFunc {
     signature: Signature,
 }
 
 impl split_to_multimap_varchar_varchar_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(3, Volatility::Immutable),
         }
@@ -79,6 +80,7 @@ impl ScalarUDFImpl for split_to_multimap_varchar_varchar_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         split_to_multimap_varchar_varchar_varchar_return_type(arg_types)
     }
@@ -87,7 +89,12 @@ impl ScalarUDFImpl for split_to_multimap_varchar_varchar_varcharFunc {
         split_to_multimap_varchar_varchar_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         split_to_multimap_varchar_varchar_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/spooky_hash_v2_32_impl.rs
+++ b/src/trino/spooky_hash_v2_32_impl.rs
@@ -50,13 +50,14 @@ fn spooky_hash_v2_32_varbinary_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct spooky_hash_v2_32_varbinaryFunc {
     signature: Signature,
 }
 
 impl spooky_hash_v2_32_varbinaryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for spooky_hash_v2_32_varbinaryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         spooky_hash_v2_32_varbinary_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for spooky_hash_v2_32_varbinaryFunc {
         spooky_hash_v2_32_varbinary_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         spooky_hash_v2_32_varbinary_simplify(args, info)
     }
+
 }

--- a/src/trino/spooky_hash_v2_64_impl.rs
+++ b/src/trino/spooky_hash_v2_64_impl.rs
@@ -50,13 +50,14 @@ fn spooky_hash_v2_64_varbinary_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct spooky_hash_v2_64_varbinaryFunc {
     signature: Signature,
 }
 
 impl spooky_hash_v2_64_varbinaryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for spooky_hash_v2_64_varbinaryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         spooky_hash_v2_64_varbinary_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for spooky_hash_v2_64_varbinaryFunc {
         spooky_hash_v2_64_varbinary_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         spooky_hash_v2_64_varbinary_simplify(args, info)
     }
+
 }

--- a/src/trino/sqrt_impl.rs
+++ b/src/trino/sqrt_impl.rs
@@ -47,13 +47,14 @@ fn sqrt_double_simplify(args: Vec<Expr>, _info: &dyn SimplifyInfo) -> Result<Exp
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct sqrt_doubleFunc {
     signature: Signature,
 }
 
 impl sqrt_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -72,6 +73,7 @@ impl ScalarUDFImpl for sqrt_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         sqrt_double_return_type(arg_types)
     }
@@ -80,7 +82,12 @@ impl ScalarUDFImpl for sqrt_doubleFunc {
         sqrt_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         sqrt_double_simplify(args, info)
     }
+
 }

--- a/src/trino/st_area_impl.rs
+++ b/src/trino/st_area_impl.rs
@@ -73,13 +73,14 @@ fn st_area_sphericalgeography_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct st_area_geometryFunc {
     signature: Signature,
 }
 
 impl st_area_geometryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -98,6 +99,7 @@ impl ScalarUDFImpl for st_area_geometryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_area_geometry_return_type(arg_types)
     }
@@ -106,9 +108,14 @@ impl ScalarUDFImpl for st_area_geometryFunc {
         st_area_geometry_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_area_geometry_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -117,7 +124,7 @@ pub(super) struct st_area_sphericalgeographyFunc {
 }
 
 impl st_area_sphericalgeographyFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -136,6 +143,7 @@ impl ScalarUDFImpl for st_area_sphericalgeographyFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_area_sphericalgeography_return_type(arg_types)
     }
@@ -144,7 +152,12 @@ impl ScalarUDFImpl for st_area_sphericalgeographyFunc {
         st_area_sphericalgeography_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_area_sphericalgeography_simplify(args, info)
     }
+
 }

--- a/src/trino/st_asbinary_impl.rs
+++ b/src/trino/st_asbinary_impl.rs
@@ -50,13 +50,14 @@ fn st_asbinary_geometry_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct st_asbinary_geometryFunc {
     signature: Signature,
 }
 
 impl st_asbinary_geometryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for st_asbinary_geometryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_asbinary_geometry_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for st_asbinary_geometryFunc {
         st_asbinary_geometry_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_asbinary_geometry_simplify(args, info)
     }
+
 }

--- a/src/trino/st_astext_impl.rs
+++ b/src/trino/st_astext_impl.rs
@@ -50,13 +50,14 @@ fn st_astext_geometry_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct st_astext_geometryFunc {
     signature: Signature,
 }
 
 impl st_astext_geometryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for st_astext_geometryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_astext_geometry_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for st_astext_geometryFunc {
         st_astext_geometry_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_astext_geometry_simplify(args, info)
     }
+
 }

--- a/src/trino/st_boundary_impl.rs
+++ b/src/trino/st_boundary_impl.rs
@@ -50,13 +50,14 @@ fn st_boundary_geometry_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct st_boundary_geometryFunc {
     signature: Signature,
 }
 
 impl st_boundary_geometryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for st_boundary_geometryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_boundary_geometry_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for st_boundary_geometryFunc {
         st_boundary_geometry_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_boundary_geometry_simplify(args, info)
     }
+
 }

--- a/src/trino/st_buffer_impl.rs
+++ b/src/trino/st_buffer_impl.rs
@@ -50,13 +50,14 @@ fn st_buffer_geometry_double_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct st_buffer_geometry_doubleFunc {
     signature: Signature,
 }
 
 impl st_buffer_geometry_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for st_buffer_geometry_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_buffer_geometry_double_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for st_buffer_geometry_doubleFunc {
         st_buffer_geometry_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_buffer_geometry_double_simplify(args, info)
     }
+
 }

--- a/src/trino/st_centroid_impl.rs
+++ b/src/trino/st_centroid_impl.rs
@@ -50,13 +50,14 @@ fn st_centroid_geometry_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct st_centroid_geometryFunc {
     signature: Signature,
 }
 
 impl st_centroid_geometryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for st_centroid_geometryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_centroid_geometry_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for st_centroid_geometryFunc {
         st_centroid_geometry_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_centroid_geometry_simplify(args, info)
     }
+
 }

--- a/src/trino/st_contains_impl.rs
+++ b/src/trino/st_contains_impl.rs
@@ -50,13 +50,14 @@ fn st_contains_geometry_geometry_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct st_contains_geometry_geometryFunc {
     signature: Signature,
 }
 
 impl st_contains_geometry_geometryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for st_contains_geometry_geometryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_contains_geometry_geometry_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for st_contains_geometry_geometryFunc {
         st_contains_geometry_geometry_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_contains_geometry_geometry_simplify(args, info)
     }
+
 }

--- a/src/trino/st_convexhull_impl.rs
+++ b/src/trino/st_convexhull_impl.rs
@@ -50,13 +50,14 @@ fn st_convexhull_geometry_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct st_convexhull_geometryFunc {
     signature: Signature,
 }
 
 impl st_convexhull_geometryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for st_convexhull_geometryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_convexhull_geometry_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for st_convexhull_geometryFunc {
         st_convexhull_geometry_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_convexhull_geometry_simplify(args, info)
     }
+
 }

--- a/src/trino/st_coorddim_impl.rs
+++ b/src/trino/st_coorddim_impl.rs
@@ -50,13 +50,14 @@ fn st_coorddim_geometry_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct st_coorddim_geometryFunc {
     signature: Signature,
 }
 
 impl st_coorddim_geometryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for st_coorddim_geometryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_coorddim_geometry_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for st_coorddim_geometryFunc {
         st_coorddim_geometry_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_coorddim_geometry_simplify(args, info)
     }
+
 }

--- a/src/trino/st_crosses_impl.rs
+++ b/src/trino/st_crosses_impl.rs
@@ -50,13 +50,14 @@ fn st_crosses_geometry_geometry_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct st_crosses_geometry_geometryFunc {
     signature: Signature,
 }
 
 impl st_crosses_geometry_geometryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for st_crosses_geometry_geometryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_crosses_geometry_geometry_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for st_crosses_geometry_geometryFunc {
         st_crosses_geometry_geometry_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_crosses_geometry_geometry_simplify(args, info)
     }
+
 }

--- a/src/trino/st_difference_impl.rs
+++ b/src/trino/st_difference_impl.rs
@@ -50,13 +50,14 @@ fn st_difference_geometry_geometry_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct st_difference_geometry_geometryFunc {
     signature: Signature,
 }
 
 impl st_difference_geometry_geometryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for st_difference_geometry_geometryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_difference_geometry_geometry_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for st_difference_geometry_geometryFunc {
         st_difference_geometry_geometry_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_difference_geometry_geometry_simplify(args, info)
     }
+
 }

--- a/src/trino/st_dimension_impl.rs
+++ b/src/trino/st_dimension_impl.rs
@@ -50,13 +50,14 @@ fn st_dimension_geometry_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct st_dimension_geometryFunc {
     signature: Signature,
 }
 
 impl st_dimension_geometryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for st_dimension_geometryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_dimension_geometry_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for st_dimension_geometryFunc {
         st_dimension_geometry_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_dimension_geometry_simplify(args, info)
     }
+
 }

--- a/src/trino/st_disjoint_impl.rs
+++ b/src/trino/st_disjoint_impl.rs
@@ -50,13 +50,14 @@ fn st_disjoint_geometry_geometry_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct st_disjoint_geometry_geometryFunc {
     signature: Signature,
 }
 
 impl st_disjoint_geometry_geometryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for st_disjoint_geometry_geometryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_disjoint_geometry_geometry_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for st_disjoint_geometry_geometryFunc {
         st_disjoint_geometry_geometry_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_disjoint_geometry_geometry_simplify(args, info)
     }
+
 }

--- a/src/trino/st_distance_impl.rs
+++ b/src/trino/st_distance_impl.rs
@@ -77,13 +77,14 @@ fn st_distance_sphericalgeography_sphericalgeography_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct st_distance_geometry_geometryFunc {
     signature: Signature,
 }
 
 impl st_distance_geometry_geometryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -102,6 +103,7 @@ impl ScalarUDFImpl for st_distance_geometry_geometryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_distance_geometry_geometry_return_type(arg_types)
     }
@@ -110,9 +112,14 @@ impl ScalarUDFImpl for st_distance_geometry_geometryFunc {
         st_distance_geometry_geometry_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_distance_geometry_geometry_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -121,7 +128,7 @@ pub(super) struct st_distance_sphericalgeography_sphericalgeographyFunc {
 }
 
 impl st_distance_sphericalgeography_sphericalgeographyFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -140,6 +147,7 @@ impl ScalarUDFImpl for st_distance_sphericalgeography_sphericalgeographyFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_distance_sphericalgeography_sphericalgeography_return_type(arg_types)
     }
@@ -148,7 +156,12 @@ impl ScalarUDFImpl for st_distance_sphericalgeography_sphericalgeographyFunc {
         st_distance_sphericalgeography_sphericalgeography_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_distance_sphericalgeography_sphericalgeography_simplify(args, info)
     }
+
 }

--- a/src/trino/st_endpoint_impl.rs
+++ b/src/trino/st_endpoint_impl.rs
@@ -50,13 +50,14 @@ fn st_endpoint_geometry_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct st_endpoint_geometryFunc {
     signature: Signature,
 }
 
 impl st_endpoint_geometryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for st_endpoint_geometryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_endpoint_geometry_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for st_endpoint_geometryFunc {
         st_endpoint_geometry_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_endpoint_geometry_simplify(args, info)
     }
+
 }

--- a/src/trino/st_envelope_impl.rs
+++ b/src/trino/st_envelope_impl.rs
@@ -50,13 +50,14 @@ fn st_envelope_geometry_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct st_envelope_geometryFunc {
     signature: Signature,
 }
 
 impl st_envelope_geometryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for st_envelope_geometryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_envelope_geometry_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for st_envelope_geometryFunc {
         st_envelope_geometry_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_envelope_geometry_simplify(args, info)
     }
+
 }

--- a/src/trino/st_envelopeaspts_impl.rs
+++ b/src/trino/st_envelopeaspts_impl.rs
@@ -50,13 +50,14 @@ fn st_envelopeaspts_geometry_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct st_envelopeaspts_geometryFunc {
     signature: Signature,
 }
 
 impl st_envelopeaspts_geometryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for st_envelopeaspts_geometryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_envelopeaspts_geometry_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for st_envelopeaspts_geometryFunc {
         st_envelopeaspts_geometry_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_envelopeaspts_geometry_simplify(args, info)
     }
+
 }

--- a/src/trino/st_equals_impl.rs
+++ b/src/trino/st_equals_impl.rs
@@ -50,13 +50,14 @@ fn st_equals_geometry_geometry_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct st_equals_geometry_geometryFunc {
     signature: Signature,
 }
 
 impl st_equals_geometry_geometryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for st_equals_geometry_geometryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_equals_geometry_geometry_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for st_equals_geometry_geometryFunc {
         st_equals_geometry_geometry_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_equals_geometry_geometry_simplify(args, info)
     }
+
 }

--- a/src/trino/st_exteriorring_impl.rs
+++ b/src/trino/st_exteriorring_impl.rs
@@ -50,13 +50,14 @@ fn st_exteriorring_geometry_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct st_exteriorring_geometryFunc {
     signature: Signature,
 }
 
 impl st_exteriorring_geometryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for st_exteriorring_geometryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_exteriorring_geometry_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for st_exteriorring_geometryFunc {
         st_exteriorring_geometry_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_exteriorring_geometry_simplify(args, info)
     }
+
 }

--- a/src/trino/st_geometries_impl.rs
+++ b/src/trino/st_geometries_impl.rs
@@ -50,13 +50,14 @@ fn st_geometries_geometry_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct st_geometries_geometryFunc {
     signature: Signature,
 }
 
 impl st_geometries_geometryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for st_geometries_geometryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_geometries_geometry_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for st_geometries_geometryFunc {
         st_geometries_geometry_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_geometries_geometry_simplify(args, info)
     }
+
 }

--- a/src/trino/st_geometryfromtext_impl.rs
+++ b/src/trino/st_geometryfromtext_impl.rs
@@ -50,13 +50,14 @@ fn st_geometryfromtext_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct st_geometryfromtext_varcharFunc {
     signature: Signature,
 }
 
 impl st_geometryfromtext_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for st_geometryfromtext_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_geometryfromtext_varchar_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for st_geometryfromtext_varcharFunc {
         st_geometryfromtext_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_geometryfromtext_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/st_geometryn_impl.rs
+++ b/src/trino/st_geometryn_impl.rs
@@ -50,13 +50,14 @@ fn st_geometryn_geometry_bigint_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct st_geometryn_geometry_bigintFunc {
     signature: Signature,
 }
 
 impl st_geometryn_geometry_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for st_geometryn_geometry_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_geometryn_geometry_bigint_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for st_geometryn_geometry_bigintFunc {
         st_geometryn_geometry_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_geometryn_geometry_bigint_simplify(args, info)
     }
+
 }

--- a/src/trino/st_geometrytype_impl.rs
+++ b/src/trino/st_geometrytype_impl.rs
@@ -50,13 +50,14 @@ fn st_geometrytype_geometry_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct st_geometrytype_geometryFunc {
     signature: Signature,
 }
 
 impl st_geometrytype_geometryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for st_geometrytype_geometryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_geometrytype_geometry_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for st_geometrytype_geometryFunc {
         st_geometrytype_geometry_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_geometrytype_geometry_simplify(args, info)
     }
+
 }

--- a/src/trino/st_geomfrombinary_impl.rs
+++ b/src/trino/st_geomfrombinary_impl.rs
@@ -50,13 +50,14 @@ fn st_geomfrombinary_varbinary_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct st_geomfrombinary_varbinaryFunc {
     signature: Signature,
 }
 
 impl st_geomfrombinary_varbinaryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for st_geomfrombinary_varbinaryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_geomfrombinary_varbinary_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for st_geomfrombinary_varbinaryFunc {
         st_geomfrombinary_varbinary_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_geomfrombinary_varbinary_simplify(args, info)
     }
+
 }

--- a/src/trino/st_interiorringn_impl.rs
+++ b/src/trino/st_interiorringn_impl.rs
@@ -50,13 +50,14 @@ fn st_interiorringn_geometry_bigint_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct st_interiorringn_geometry_bigintFunc {
     signature: Signature,
 }
 
 impl st_interiorringn_geometry_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for st_interiorringn_geometry_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_interiorringn_geometry_bigint_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for st_interiorringn_geometry_bigintFunc {
         st_interiorringn_geometry_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_interiorringn_geometry_bigint_simplify(args, info)
     }
+
 }

--- a/src/trino/st_interiorrings_impl.rs
+++ b/src/trino/st_interiorrings_impl.rs
@@ -50,13 +50,14 @@ fn st_interiorrings_geometry_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct st_interiorrings_geometryFunc {
     signature: Signature,
 }
 
 impl st_interiorrings_geometryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for st_interiorrings_geometryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_interiorrings_geometry_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for st_interiorrings_geometryFunc {
         st_interiorrings_geometry_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_interiorrings_geometry_simplify(args, info)
     }
+
 }

--- a/src/trino/st_intersection_impl.rs
+++ b/src/trino/st_intersection_impl.rs
@@ -50,13 +50,14 @@ fn st_intersection_geometry_geometry_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct st_intersection_geometry_geometryFunc {
     signature: Signature,
 }
 
 impl st_intersection_geometry_geometryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for st_intersection_geometry_geometryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_intersection_geometry_geometry_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for st_intersection_geometry_geometryFunc {
         st_intersection_geometry_geometry_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_intersection_geometry_geometry_simplify(args, info)
     }
+
 }

--- a/src/trino/st_intersects_impl.rs
+++ b/src/trino/st_intersects_impl.rs
@@ -50,13 +50,14 @@ fn st_intersects_geometry_geometry_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct st_intersects_geometry_geometryFunc {
     signature: Signature,
 }
 
 impl st_intersects_geometry_geometryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for st_intersects_geometry_geometryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_intersects_geometry_geometry_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for st_intersects_geometry_geometryFunc {
         st_intersects_geometry_geometry_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_intersects_geometry_geometry_simplify(args, info)
     }
+
 }

--- a/src/trino/st_isclosed_impl.rs
+++ b/src/trino/st_isclosed_impl.rs
@@ -50,13 +50,14 @@ fn st_isclosed_geometry_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct st_isclosed_geometryFunc {
     signature: Signature,
 }
 
 impl st_isclosed_geometryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for st_isclosed_geometryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_isclosed_geometry_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for st_isclosed_geometryFunc {
         st_isclosed_geometry_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_isclosed_geometry_simplify(args, info)
     }
+
 }

--- a/src/trino/st_isempty_impl.rs
+++ b/src/trino/st_isempty_impl.rs
@@ -50,13 +50,14 @@ fn st_isempty_geometry_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct st_isempty_geometryFunc {
     signature: Signature,
 }
 
 impl st_isempty_geometryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for st_isempty_geometryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_isempty_geometry_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for st_isempty_geometryFunc {
         st_isempty_geometry_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_isempty_geometry_simplify(args, info)
     }
+
 }

--- a/src/trino/st_isring_impl.rs
+++ b/src/trino/st_isring_impl.rs
@@ -50,13 +50,14 @@ fn st_isring_geometry_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct st_isring_geometryFunc {
     signature: Signature,
 }
 
 impl st_isring_geometryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for st_isring_geometryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_isring_geometry_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for st_isring_geometryFunc {
         st_isring_geometry_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_isring_geometry_simplify(args, info)
     }
+
 }

--- a/src/trino/st_issimple_impl.rs
+++ b/src/trino/st_issimple_impl.rs
@@ -50,13 +50,14 @@ fn st_issimple_geometry_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct st_issimple_geometryFunc {
     signature: Signature,
 }
 
 impl st_issimple_geometryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for st_issimple_geometryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_issimple_geometry_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for st_issimple_geometryFunc {
         st_issimple_geometry_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_issimple_geometry_simplify(args, info)
     }
+
 }

--- a/src/trino/st_isvalid_impl.rs
+++ b/src/trino/st_isvalid_impl.rs
@@ -50,13 +50,14 @@ fn st_isvalid_geometry_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct st_isvalid_geometryFunc {
     signature: Signature,
 }
 
 impl st_isvalid_geometryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for st_isvalid_geometryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_isvalid_geometry_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for st_isvalid_geometryFunc {
         st_isvalid_geometry_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_isvalid_geometry_simplify(args, info)
     }
+
 }

--- a/src/trino/st_length_impl.rs
+++ b/src/trino/st_length_impl.rs
@@ -73,13 +73,14 @@ fn st_length_sphericalgeography_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct st_length_geometryFunc {
     signature: Signature,
 }
 
 impl st_length_geometryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -98,6 +99,7 @@ impl ScalarUDFImpl for st_length_geometryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_length_geometry_return_type(arg_types)
     }
@@ -106,9 +108,14 @@ impl ScalarUDFImpl for st_length_geometryFunc {
         st_length_geometry_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_length_geometry_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -117,7 +124,7 @@ pub(super) struct st_length_sphericalgeographyFunc {
 }
 
 impl st_length_sphericalgeographyFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -136,6 +143,7 @@ impl ScalarUDFImpl for st_length_sphericalgeographyFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_length_sphericalgeography_return_type(arg_types)
     }
@@ -144,7 +152,12 @@ impl ScalarUDFImpl for st_length_sphericalgeographyFunc {
         st_length_sphericalgeography_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_length_sphericalgeography_simplify(args, info)
     }
+
 }

--- a/src/trino/st_linefromtext_impl.rs
+++ b/src/trino/st_linefromtext_impl.rs
@@ -50,13 +50,14 @@ fn st_linefromtext_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct st_linefromtext_varcharFunc {
     signature: Signature,
 }
 
 impl st_linefromtext_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for st_linefromtext_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_linefromtext_varchar_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for st_linefromtext_varcharFunc {
         st_linefromtext_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_linefromtext_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/st_linestring_impl.rs
+++ b/src/trino/st_linestring_impl.rs
@@ -50,13 +50,14 @@ fn st_linestring_array_geometry_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct st_linestring_array_geometryFunc {
     signature: Signature,
 }
 
 impl st_linestring_array_geometryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for st_linestring_array_geometryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_linestring_array_geometry_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for st_linestring_array_geometryFunc {
         st_linestring_array_geometry_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_linestring_array_geometry_simplify(args, info)
     }
+
 }

--- a/src/trino/st_multipoint_impl.rs
+++ b/src/trino/st_multipoint_impl.rs
@@ -50,13 +50,14 @@ fn st_multipoint_array_geometry_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct st_multipoint_array_geometryFunc {
     signature: Signature,
 }
 
 impl st_multipoint_array_geometryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for st_multipoint_array_geometryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_multipoint_array_geometry_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for st_multipoint_array_geometryFunc {
         st_multipoint_array_geometry_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_multipoint_array_geometry_simplify(args, info)
     }
+
 }

--- a/src/trino/st_numgeometries_impl.rs
+++ b/src/trino/st_numgeometries_impl.rs
@@ -50,13 +50,14 @@ fn st_numgeometries_geometry_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct st_numgeometries_geometryFunc {
     signature: Signature,
 }
 
 impl st_numgeometries_geometryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for st_numgeometries_geometryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_numgeometries_geometry_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for st_numgeometries_geometryFunc {
         st_numgeometries_geometry_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_numgeometries_geometry_simplify(args, info)
     }
+
 }

--- a/src/trino/st_numinteriorring_impl.rs
+++ b/src/trino/st_numinteriorring_impl.rs
@@ -50,13 +50,14 @@ fn st_numinteriorring_geometry_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct st_numinteriorring_geometryFunc {
     signature: Signature,
 }
 
 impl st_numinteriorring_geometryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for st_numinteriorring_geometryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_numinteriorring_geometry_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for st_numinteriorring_geometryFunc {
         st_numinteriorring_geometry_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_numinteriorring_geometry_simplify(args, info)
     }
+
 }

--- a/src/trino/st_numpoints_impl.rs
+++ b/src/trino/st_numpoints_impl.rs
@@ -50,13 +50,14 @@ fn st_numpoints_geometry_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct st_numpoints_geometryFunc {
     signature: Signature,
 }
 
 impl st_numpoints_geometryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for st_numpoints_geometryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_numpoints_geometry_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for st_numpoints_geometryFunc {
         st_numpoints_geometry_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_numpoints_geometry_simplify(args, info)
     }
+
 }

--- a/src/trino/st_overlaps_impl.rs
+++ b/src/trino/st_overlaps_impl.rs
@@ -50,13 +50,14 @@ fn st_overlaps_geometry_geometry_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct st_overlaps_geometry_geometryFunc {
     signature: Signature,
 }
 
 impl st_overlaps_geometry_geometryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for st_overlaps_geometry_geometryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_overlaps_geometry_geometry_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for st_overlaps_geometry_geometryFunc {
         st_overlaps_geometry_geometry_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_overlaps_geometry_geometry_simplify(args, info)
     }
+
 }

--- a/src/trino/st_point_impl.rs
+++ b/src/trino/st_point_impl.rs
@@ -50,13 +50,14 @@ fn st_point_double_double_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct st_point_double_doubleFunc {
     signature: Signature,
 }
 
 impl st_point_double_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for st_point_double_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_point_double_double_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for st_point_double_doubleFunc {
         st_point_double_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_point_double_double_simplify(args, info)
     }
+
 }

--- a/src/trino/st_pointn_impl.rs
+++ b/src/trino/st_pointn_impl.rs
@@ -50,13 +50,14 @@ fn st_pointn_geometry_bigint_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct st_pointn_geometry_bigintFunc {
     signature: Signature,
 }
 
 impl st_pointn_geometry_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for st_pointn_geometry_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_pointn_geometry_bigint_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for st_pointn_geometry_bigintFunc {
         st_pointn_geometry_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_pointn_geometry_bigint_simplify(args, info)
     }
+
 }

--- a/src/trino/st_points_impl.rs
+++ b/src/trino/st_points_impl.rs
@@ -50,13 +50,14 @@ fn st_points_geometry_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct st_points_geometryFunc {
     signature: Signature,
 }
 
 impl st_points_geometryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for st_points_geometryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_points_geometry_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for st_points_geometryFunc {
         st_points_geometry_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_points_geometry_simplify(args, info)
     }
+
 }

--- a/src/trino/st_polygon_impl.rs
+++ b/src/trino/st_polygon_impl.rs
@@ -50,13 +50,14 @@ fn st_polygon_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct st_polygon_varcharFunc {
     signature: Signature,
 }
 
 impl st_polygon_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for st_polygon_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_polygon_varchar_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for st_polygon_varcharFunc {
         st_polygon_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_polygon_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/st_relate_impl.rs
+++ b/src/trino/st_relate_impl.rs
@@ -50,13 +50,14 @@ fn st_relate_geometry_geometry_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct st_relate_geometry_geometry_varcharFunc {
     signature: Signature,
 }
 
 impl st_relate_geometry_geometry_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(3, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for st_relate_geometry_geometry_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_relate_geometry_geometry_varchar_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for st_relate_geometry_geometry_varcharFunc {
         st_relate_geometry_geometry_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_relate_geometry_geometry_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/st_startpoint_impl.rs
+++ b/src/trino/st_startpoint_impl.rs
@@ -50,13 +50,14 @@ fn st_startpoint_geometry_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct st_startpoint_geometryFunc {
     signature: Signature,
 }
 
 impl st_startpoint_geometryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for st_startpoint_geometryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_startpoint_geometry_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for st_startpoint_geometryFunc {
         st_startpoint_geometry_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_startpoint_geometry_simplify(args, info)
     }
+
 }

--- a/src/trino/st_symdifference_impl.rs
+++ b/src/trino/st_symdifference_impl.rs
@@ -50,13 +50,14 @@ fn st_symdifference_geometry_geometry_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct st_symdifference_geometry_geometryFunc {
     signature: Signature,
 }
 
 impl st_symdifference_geometry_geometryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for st_symdifference_geometry_geometryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_symdifference_geometry_geometry_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for st_symdifference_geometry_geometryFunc {
         st_symdifference_geometry_geometry_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_symdifference_geometry_geometry_simplify(args, info)
     }
+
 }

--- a/src/trino/st_touches_impl.rs
+++ b/src/trino/st_touches_impl.rs
@@ -50,13 +50,14 @@ fn st_touches_geometry_geometry_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct st_touches_geometry_geometryFunc {
     signature: Signature,
 }
 
 impl st_touches_geometry_geometryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for st_touches_geometry_geometryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_touches_geometry_geometry_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for st_touches_geometry_geometryFunc {
         st_touches_geometry_geometry_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_touches_geometry_geometry_simplify(args, info)
     }
+
 }

--- a/src/trino/st_union_impl.rs
+++ b/src/trino/st_union_impl.rs
@@ -50,13 +50,14 @@ fn st_union_geometry_geometry_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct st_union_geometry_geometryFunc {
     signature: Signature,
 }
 
 impl st_union_geometry_geometryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for st_union_geometry_geometryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_union_geometry_geometry_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for st_union_geometry_geometryFunc {
         st_union_geometry_geometry_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_union_geometry_geometry_simplify(args, info)
     }
+
 }

--- a/src/trino/st_within_impl.rs
+++ b/src/trino/st_within_impl.rs
@@ -50,13 +50,14 @@ fn st_within_geometry_geometry_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct st_within_geometry_geometryFunc {
     signature: Signature,
 }
 
 impl st_within_geometry_geometryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for st_within_geometry_geometryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_within_geometry_geometry_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for st_within_geometry_geometryFunc {
         st_within_geometry_geometry_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_within_geometry_geometry_simplify(args, info)
     }
+
 }

--- a/src/trino/st_x_impl.rs
+++ b/src/trino/st_x_impl.rs
@@ -47,13 +47,14 @@ fn st_x_geometry_simplify(args: Vec<Expr>, _info: &dyn SimplifyInfo) -> Result<E
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct st_x_geometryFunc {
     signature: Signature,
 }
 
 impl st_x_geometryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -72,6 +73,7 @@ impl ScalarUDFImpl for st_x_geometryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_x_geometry_return_type(arg_types)
     }
@@ -80,7 +82,12 @@ impl ScalarUDFImpl for st_x_geometryFunc {
         st_x_geometry_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_x_geometry_simplify(args, info)
     }
+
 }

--- a/src/trino/st_xmax_impl.rs
+++ b/src/trino/st_xmax_impl.rs
@@ -50,13 +50,14 @@ fn st_xmax_geometry_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct st_xmax_geometryFunc {
     signature: Signature,
 }
 
 impl st_xmax_geometryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for st_xmax_geometryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_xmax_geometry_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for st_xmax_geometryFunc {
         st_xmax_geometry_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_xmax_geometry_simplify(args, info)
     }
+
 }

--- a/src/trino/st_xmin_impl.rs
+++ b/src/trino/st_xmin_impl.rs
@@ -50,13 +50,14 @@ fn st_xmin_geometry_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct st_xmin_geometryFunc {
     signature: Signature,
 }
 
 impl st_xmin_geometryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for st_xmin_geometryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_xmin_geometry_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for st_xmin_geometryFunc {
         st_xmin_geometry_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_xmin_geometry_simplify(args, info)
     }
+
 }

--- a/src/trino/st_y_impl.rs
+++ b/src/trino/st_y_impl.rs
@@ -47,13 +47,14 @@ fn st_y_geometry_simplify(args: Vec<Expr>, _info: &dyn SimplifyInfo) -> Result<E
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct st_y_geometryFunc {
     signature: Signature,
 }
 
 impl st_y_geometryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -72,6 +73,7 @@ impl ScalarUDFImpl for st_y_geometryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_y_geometry_return_type(arg_types)
     }
@@ -80,7 +82,12 @@ impl ScalarUDFImpl for st_y_geometryFunc {
         st_y_geometry_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_y_geometry_simplify(args, info)
     }
+
 }

--- a/src/trino/st_ymax_impl.rs
+++ b/src/trino/st_ymax_impl.rs
@@ -50,13 +50,14 @@ fn st_ymax_geometry_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct st_ymax_geometryFunc {
     signature: Signature,
 }
 
 impl st_ymax_geometryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for st_ymax_geometryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_ymax_geometry_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for st_ymax_geometryFunc {
         st_ymax_geometry_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_ymax_geometry_simplify(args, info)
     }
+
 }

--- a/src/trino/st_ymin_impl.rs
+++ b/src/trino/st_ymin_impl.rs
@@ -50,13 +50,14 @@ fn st_ymin_geometry_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct st_ymin_geometryFunc {
     signature: Signature,
 }
 
 impl st_ymin_geometryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for st_ymin_geometryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         st_ymin_geometry_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for st_ymin_geometryFunc {
         st_ymin_geometry_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         st_ymin_geometry_simplify(args, info)
     }
+
 }

--- a/src/trino/starts_with_impl.rs
+++ b/src/trino/starts_with_impl.rs
@@ -50,13 +50,14 @@ fn starts_with_varchar_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct starts_with_varchar_varcharFunc {
     signature: Signature,
 }
 
 impl starts_with_varchar_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for starts_with_varchar_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         starts_with_varchar_varchar_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for starts_with_varchar_varcharFunc {
         starts_with_varchar_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         starts_with_varchar_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/strpos_impl.rs
+++ b/src/trino/strpos_impl.rs
@@ -73,13 +73,14 @@ fn strpos_varchar_varchar_bigint_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct strpos_varchar_varcharFunc {
     signature: Signature,
 }
 
 impl strpos_varchar_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -98,6 +99,7 @@ impl ScalarUDFImpl for strpos_varchar_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         strpos_varchar_varchar_return_type(arg_types)
     }
@@ -106,9 +108,14 @@ impl ScalarUDFImpl for strpos_varchar_varcharFunc {
         strpos_varchar_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         strpos_varchar_varchar_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -117,7 +124,7 @@ pub(super) struct strpos_varchar_varchar_bigintFunc {
 }
 
 impl strpos_varchar_varchar_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(3, Volatility::Immutable),
         }
@@ -136,6 +143,7 @@ impl ScalarUDFImpl for strpos_varchar_varchar_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         strpos_varchar_varchar_bigint_return_type(arg_types)
     }
@@ -144,7 +152,12 @@ impl ScalarUDFImpl for strpos_varchar_varchar_bigintFunc {
         strpos_varchar_varchar_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         strpos_varchar_varchar_bigint_simplify(args, info)
     }
+
 }

--- a/src/trino/substr_impl.rs
+++ b/src/trino/substr_impl.rs
@@ -119,13 +119,14 @@ fn substr_varbinary_bigint_bigint_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct substr_varchar_bigintFunc {
     signature: Signature,
 }
 
 impl substr_varchar_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -144,6 +145,7 @@ impl ScalarUDFImpl for substr_varchar_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         substr_varchar_bigint_return_type(arg_types)
     }
@@ -152,9 +154,14 @@ impl ScalarUDFImpl for substr_varchar_bigintFunc {
         substr_varchar_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         substr_varchar_bigint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -163,7 +170,7 @@ pub(super) struct substr_varchar_bigint_bigintFunc {
 }
 
 impl substr_varchar_bigint_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(3, Volatility::Immutable),
         }
@@ -182,6 +189,7 @@ impl ScalarUDFImpl for substr_varchar_bigint_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         substr_varchar_bigint_bigint_return_type(arg_types)
     }
@@ -190,9 +198,14 @@ impl ScalarUDFImpl for substr_varchar_bigint_bigintFunc {
         substr_varchar_bigint_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         substr_varchar_bigint_bigint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -201,7 +214,7 @@ pub(super) struct substr_varbinary_bigintFunc {
 }
 
 impl substr_varbinary_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -220,6 +233,7 @@ impl ScalarUDFImpl for substr_varbinary_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         substr_varbinary_bigint_return_type(arg_types)
     }
@@ -228,9 +242,14 @@ impl ScalarUDFImpl for substr_varbinary_bigintFunc {
         substr_varbinary_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         substr_varbinary_bigint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -239,7 +258,7 @@ pub(super) struct substr_varbinary_bigint_bigintFunc {
 }
 
 impl substr_varbinary_bigint_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(3, Volatility::Immutable),
         }
@@ -258,6 +277,7 @@ impl ScalarUDFImpl for substr_varbinary_bigint_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         substr_varbinary_bigint_bigint_return_type(arg_types)
     }
@@ -266,7 +286,12 @@ impl ScalarUDFImpl for substr_varbinary_bigint_bigintFunc {
         substr_varbinary_bigint_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         substr_varbinary_bigint_bigint_simplify(args, info)
     }
+
 }

--- a/src/trino/substring_impl.rs
+++ b/src/trino/substring_impl.rs
@@ -73,13 +73,14 @@ fn substring_varchar_bigint_bigint_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct substring_varchar_bigintFunc {
     signature: Signature,
 }
 
 impl substring_varchar_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -98,6 +99,7 @@ impl ScalarUDFImpl for substring_varchar_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         substring_varchar_bigint_return_type(arg_types)
     }
@@ -106,9 +108,14 @@ impl ScalarUDFImpl for substring_varchar_bigintFunc {
         substring_varchar_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         substring_varchar_bigint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -117,7 +124,7 @@ pub(super) struct substring_varchar_bigint_bigintFunc {
 }
 
 impl substring_varchar_bigint_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(3, Volatility::Immutable),
         }
@@ -136,6 +143,7 @@ impl ScalarUDFImpl for substring_varchar_bigint_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         substring_varchar_bigint_bigint_return_type(arg_types)
     }
@@ -144,7 +152,12 @@ impl ScalarUDFImpl for substring_varchar_bigint_bigintFunc {
         substring_varchar_bigint_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         substring_varchar_bigint_bigint_simplify(args, info)
     }
+
 }

--- a/src/trino/tan_impl.rs
+++ b/src/trino/tan_impl.rs
@@ -47,13 +47,14 @@ fn tan_double_simplify(args: Vec<Expr>, _info: &dyn SimplifyInfo) -> Result<Expr
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct tan_doubleFunc {
     signature: Signature,
 }
 
 impl tan_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -72,6 +73,7 @@ impl ScalarUDFImpl for tan_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         tan_double_return_type(arg_types)
     }
@@ -80,7 +82,12 @@ impl ScalarUDFImpl for tan_doubleFunc {
         tan_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         tan_double_simplify(args, info)
     }
+
 }

--- a/src/trino/tanh_impl.rs
+++ b/src/trino/tanh_impl.rs
@@ -47,13 +47,14 @@ fn tanh_double_simplify(args: Vec<Expr>, _info: &dyn SimplifyInfo) -> Result<Exp
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct tanh_doubleFunc {
     signature: Signature,
 }
 
 impl tanh_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -72,6 +73,7 @@ impl ScalarUDFImpl for tanh_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         tanh_double_return_type(arg_types)
     }
@@ -80,7 +82,12 @@ impl ScalarUDFImpl for tanh_doubleFunc {
         tanh_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         tanh_double_simplify(args, info)
     }
+
 }

--- a/src/trino/timestamp_objectid_impl.rs
+++ b/src/trino/timestamp_objectid_impl.rs
@@ -50,13 +50,14 @@ fn timestamp_objectid_timestamp_0_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct timestamp_objectid_timestamp_0Func {
     signature: Signature,
 }
 
 impl timestamp_objectid_timestamp_0Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for timestamp_objectid_timestamp_0Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         timestamp_objectid_timestamp_0_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for timestamp_objectid_timestamp_0Func {
         timestamp_objectid_timestamp_0_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         timestamp_objectid_timestamp_0_simplify(args, info)
     }
+
 }

--- a/src/trino/timezone_hour_impl.rs
+++ b/src/trino/timezone_hour_impl.rs
@@ -73,13 +73,14 @@ fn timezone_hour_timestamp_p_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct timezone_hour_time_pFunc {
     signature: Signature,
 }
 
 impl timezone_hour_time_pFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -98,6 +99,7 @@ impl ScalarUDFImpl for timezone_hour_time_pFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         timezone_hour_time_p_return_type(arg_types)
     }
@@ -106,9 +108,14 @@ impl ScalarUDFImpl for timezone_hour_time_pFunc {
         timezone_hour_time_p_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         timezone_hour_time_p_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -117,7 +124,7 @@ pub(super) struct timezone_hour_timestamp_pFunc {
 }
 
 impl timezone_hour_timestamp_pFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -136,6 +143,7 @@ impl ScalarUDFImpl for timezone_hour_timestamp_pFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         timezone_hour_timestamp_p_return_type(arg_types)
     }
@@ -144,7 +152,12 @@ impl ScalarUDFImpl for timezone_hour_timestamp_pFunc {
         timezone_hour_timestamp_p_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         timezone_hour_timestamp_p_simplify(args, info)
     }
+
 }

--- a/src/trino/timezone_minute_impl.rs
+++ b/src/trino/timezone_minute_impl.rs
@@ -73,13 +73,14 @@ fn timezone_minute_timestamp_p_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct timezone_minute_time_pFunc {
     signature: Signature,
 }
 
 impl timezone_minute_time_pFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -98,6 +99,7 @@ impl ScalarUDFImpl for timezone_minute_time_pFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         timezone_minute_time_p_return_type(arg_types)
     }
@@ -106,9 +108,14 @@ impl ScalarUDFImpl for timezone_minute_time_pFunc {
         timezone_minute_time_p_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         timezone_minute_time_p_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -117,7 +124,7 @@ pub(super) struct timezone_minute_timestamp_pFunc {
 }
 
 impl timezone_minute_timestamp_pFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -136,6 +143,7 @@ impl ScalarUDFImpl for timezone_minute_timestamp_pFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         timezone_minute_timestamp_p_return_type(arg_types)
     }
@@ -144,7 +152,12 @@ impl ScalarUDFImpl for timezone_minute_timestamp_pFunc {
         timezone_minute_timestamp_p_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         timezone_minute_timestamp_p_simplify(args, info)
     }
+
 }

--- a/src/trino/to_base32_impl.rs
+++ b/src/trino/to_base32_impl.rs
@@ -50,13 +50,14 @@ fn to_base32_varbinary_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct to_base32_varbinaryFunc {
     signature: Signature,
 }
 
 impl to_base32_varbinaryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for to_base32_varbinaryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         to_base32_varbinary_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for to_base32_varbinaryFunc {
         to_base32_varbinary_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         to_base32_varbinary_simplify(args, info)
     }
+
 }

--- a/src/trino/to_base64_impl.rs
+++ b/src/trino/to_base64_impl.rs
@@ -50,13 +50,14 @@ fn to_base64_varbinary_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct to_base64_varbinaryFunc {
     signature: Signature,
 }
 
 impl to_base64_varbinaryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for to_base64_varbinaryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         to_base64_varbinary_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for to_base64_varbinaryFunc {
         to_base64_varbinary_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         to_base64_varbinary_simplify(args, info)
     }
+
 }

--- a/src/trino/to_base64url_impl.rs
+++ b/src/trino/to_base64url_impl.rs
@@ -50,13 +50,14 @@ fn to_base64url_varbinary_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct to_base64url_varbinaryFunc {
     signature: Signature,
 }
 
 impl to_base64url_varbinaryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for to_base64url_varbinaryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         to_base64url_varbinary_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for to_base64url_varbinaryFunc {
         to_base64url_varbinary_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         to_base64url_varbinary_simplify(args, info)
     }
+
 }

--- a/src/trino/to_base_impl.rs
+++ b/src/trino/to_base_impl.rs
@@ -50,13 +50,14 @@ fn to_base_bigint_bigint_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct to_base_bigint_bigintFunc {
     signature: Signature,
 }
 
 impl to_base_bigint_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for to_base_bigint_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         to_base_bigint_bigint_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for to_base_bigint_bigintFunc {
         to_base_bigint_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         to_base_bigint_bigint_simplify(args, info)
     }
+
 }

--- a/src/trino/to_big_endian_32_impl.rs
+++ b/src/trino/to_big_endian_32_impl.rs
@@ -50,13 +50,14 @@ fn to_big_endian_32_bigint_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct to_big_endian_32_bigintFunc {
     signature: Signature,
 }
 
 impl to_big_endian_32_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for to_big_endian_32_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         to_big_endian_32_bigint_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for to_big_endian_32_bigintFunc {
         to_big_endian_32_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         to_big_endian_32_bigint_simplify(args, info)
     }
+
 }

--- a/src/trino/to_big_endian_64_impl.rs
+++ b/src/trino/to_big_endian_64_impl.rs
@@ -50,13 +50,14 @@ fn to_big_endian_64_bigint_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct to_big_endian_64_bigintFunc {
     signature: Signature,
 }
 
 impl to_big_endian_64_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for to_big_endian_64_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         to_big_endian_64_bigint_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for to_big_endian_64_bigintFunc {
         to_big_endian_64_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         to_big_endian_64_bigint_simplify(args, info)
     }
+
 }

--- a/src/trino/to_char_impl.rs
+++ b/src/trino/to_char_impl.rs
@@ -50,13 +50,14 @@ fn to_char_timestamp_p_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct to_char_timestamp_p_varcharFunc {
     signature: Signature,
 }
 
 impl to_char_timestamp_p_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for to_char_timestamp_p_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         to_char_timestamp_p_varchar_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for to_char_timestamp_p_varcharFunc {
         to_char_timestamp_p_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         to_char_timestamp_p_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/to_date_impl.rs
+++ b/src/trino/to_date_impl.rs
@@ -50,13 +50,14 @@ fn to_date_varchar_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct to_date_varchar_varcharFunc {
     signature: Signature,
 }
 
 impl to_date_varchar_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for to_date_varchar_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         to_date_varchar_varchar_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for to_date_varchar_varcharFunc {
         to_date_varchar_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         to_date_varchar_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/to_encoded_polyline_impl.rs
+++ b/src/trino/to_encoded_polyline_impl.rs
@@ -50,13 +50,14 @@ fn to_encoded_polyline_geometry_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct to_encoded_polyline_geometryFunc {
     signature: Signature,
 }
 
 impl to_encoded_polyline_geometryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for to_encoded_polyline_geometryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         to_encoded_polyline_geometry_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for to_encoded_polyline_geometryFunc {
         to_encoded_polyline_geometry_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         to_encoded_polyline_geometry_simplify(args, info)
     }
+
 }

--- a/src/trino/to_geojson_geometry_impl.rs
+++ b/src/trino/to_geojson_geometry_impl.rs
@@ -50,13 +50,14 @@ fn to_geojson_geometry_sphericalgeography_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct to_geojson_geometry_sphericalgeographyFunc {
     signature: Signature,
 }
 
 impl to_geojson_geometry_sphericalgeographyFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for to_geojson_geometry_sphericalgeographyFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         to_geojson_geometry_sphericalgeography_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for to_geojson_geometry_sphericalgeographyFunc {
         to_geojson_geometry_sphericalgeography_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         to_geojson_geometry_sphericalgeography_simplify(args, info)
     }
+
 }

--- a/src/trino/to_geometry_impl.rs
+++ b/src/trino/to_geometry_impl.rs
@@ -50,13 +50,14 @@ fn to_geometry_sphericalgeography_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct to_geometry_sphericalgeographyFunc {
     signature: Signature,
 }
 
 impl to_geometry_sphericalgeographyFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for to_geometry_sphericalgeographyFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         to_geometry_sphericalgeography_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for to_geometry_sphericalgeographyFunc {
         to_geometry_sphericalgeography_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         to_geometry_sphericalgeography_simplify(args, info)
     }
+
 }

--- a/src/trino/to_hex_impl.rs
+++ b/src/trino/to_hex_impl.rs
@@ -64,13 +64,14 @@ fn to_hex_varbinary_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct to_hex_varbinaryFunc {
     signature: Signature,
 }
 
 impl to_hex_varbinaryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -89,6 +90,7 @@ impl ScalarUDFImpl for to_hex_varbinaryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         to_hex_varbinary_return_type(arg_types)
     }
@@ -97,7 +99,12 @@ impl ScalarUDFImpl for to_hex_varbinaryFunc {
         to_hex_varbinary_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         to_hex_varbinary_simplify(args, info)
     }
+
 }

--- a/src/trino/to_ieee754_32_impl.rs
+++ b/src/trino/to_ieee754_32_impl.rs
@@ -50,13 +50,14 @@ fn to_ieee754_32_real_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct to_ieee754_32_realFunc {
     signature: Signature,
 }
 
 impl to_ieee754_32_realFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for to_ieee754_32_realFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         to_ieee754_32_real_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for to_ieee754_32_realFunc {
         to_ieee754_32_real_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         to_ieee754_32_real_simplify(args, info)
     }
+
 }

--- a/src/trino/to_ieee754_64_impl.rs
+++ b/src/trino/to_ieee754_64_impl.rs
@@ -50,13 +50,14 @@ fn to_ieee754_64_double_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct to_ieee754_64_doubleFunc {
     signature: Signature,
 }
 
 impl to_ieee754_64_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for to_ieee754_64_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         to_ieee754_64_double_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for to_ieee754_64_doubleFunc {
         to_ieee754_64_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         to_ieee754_64_double_simplify(args, info)
     }
+
 }

--- a/src/trino/to_iso8601_impl.rs
+++ b/src/trino/to_iso8601_impl.rs
@@ -73,13 +73,14 @@ fn to_iso8601_timestamp_p_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct to_iso8601_dateFunc {
     signature: Signature,
 }
 
 impl to_iso8601_dateFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -98,6 +99,7 @@ impl ScalarUDFImpl for to_iso8601_dateFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         to_iso8601_date_return_type(arg_types)
     }
@@ -106,9 +108,14 @@ impl ScalarUDFImpl for to_iso8601_dateFunc {
         to_iso8601_date_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         to_iso8601_date_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -117,7 +124,7 @@ pub(super) struct to_iso8601_timestamp_pFunc {
 }
 
 impl to_iso8601_timestamp_pFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -136,6 +143,7 @@ impl ScalarUDFImpl for to_iso8601_timestamp_pFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         to_iso8601_timestamp_p_return_type(arg_types)
     }
@@ -144,7 +152,12 @@ impl ScalarUDFImpl for to_iso8601_timestamp_pFunc {
         to_iso8601_timestamp_p_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         to_iso8601_timestamp_p_simplify(args, info)
     }
+
 }

--- a/src/trino/to_milliseconds_impl.rs
+++ b/src/trino/to_milliseconds_impl.rs
@@ -50,13 +50,14 @@ fn to_milliseconds_intervaldaytosecond_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct to_milliseconds_intervaldaytosecondFunc {
     signature: Signature,
 }
 
 impl to_milliseconds_intervaldaytosecondFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for to_milliseconds_intervaldaytosecondFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         to_milliseconds_intervaldaytosecond_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for to_milliseconds_intervaldaytosecondFunc {
         to_milliseconds_intervaldaytosecond_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         to_milliseconds_intervaldaytosecond_simplify(args, info)
     }
+
 }

--- a/src/trino/to_spherical_geography_impl.rs
+++ b/src/trino/to_spherical_geography_impl.rs
@@ -50,13 +50,14 @@ fn to_spherical_geography_geometry_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct to_spherical_geography_geometryFunc {
     signature: Signature,
 }
 
 impl to_spherical_geography_geometryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for to_spherical_geography_geometryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         to_spherical_geography_geometry_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for to_spherical_geography_geometryFunc {
         to_spherical_geography_geometry_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         to_spherical_geography_geometry_simplify(args, info)
     }
+
 }

--- a/src/trino/to_timestamp_impl.rs
+++ b/src/trino/to_timestamp_impl.rs
@@ -50,13 +50,14 @@ fn to_timestamp_varchar_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct to_timestamp_varchar_varcharFunc {
     signature: Signature,
 }
 
 impl to_timestamp_varchar_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for to_timestamp_varchar_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         to_timestamp_varchar_varchar_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for to_timestamp_varchar_varcharFunc {
         to_timestamp_varchar_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         to_timestamp_varchar_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/to_unixtime_impl.rs
+++ b/src/trino/to_unixtime_impl.rs
@@ -50,13 +50,14 @@ fn to_unixtime_timestamp_p_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct to_unixtime_timestamp_pFunc {
     signature: Signature,
 }
 
 impl to_unixtime_timestamp_pFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for to_unixtime_timestamp_pFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         to_unixtime_timestamp_p_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for to_unixtime_timestamp_pFunc {
         to_unixtime_timestamp_p_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         to_unixtime_timestamp_p_simplify(args, info)
     }
+
 }

--- a/src/trino/to_utf8_impl.rs
+++ b/src/trino/to_utf8_impl.rs
@@ -50,13 +50,14 @@ fn to_utf8_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct to_utf8_varcharFunc {
     signature: Signature,
 }
 
 impl to_utf8_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for to_utf8_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         to_utf8_varchar_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for to_utf8_varcharFunc {
         to_utf8_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         to_utf8_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/transform_impl.rs
+++ b/src/trino/transform_impl.rs
@@ -50,13 +50,14 @@ fn transform_array_1_function_1_11_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct transform_array_1_function_1_11Func {
     signature: Signature,
 }
 
 impl transform_array_1_function_1_11Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for transform_array_1_function_1_11Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         transform_array_1_function_1_11_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for transform_array_1_function_1_11Func {
         transform_array_1_function_1_11_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         transform_array_1_function_1_11_simplify(args, info)
     }
+
 }

--- a/src/trino/transform_keys_impl.rs
+++ b/src/trino/transform_keys_impl.rs
@@ -54,13 +54,14 @@ fn transform_keys_map_13_5_function_13_5_12_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct transform_keys_map_13_5_function_13_5_12Func {
     signature: Signature,
 }
 
 impl transform_keys_map_13_5_function_13_5_12Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -79,6 +80,7 @@ impl ScalarUDFImpl for transform_keys_map_13_5_function_13_5_12Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         transform_keys_map_13_5_function_13_5_12_return_type(arg_types)
     }
@@ -87,7 +89,12 @@ impl ScalarUDFImpl for transform_keys_map_13_5_function_13_5_12Func {
         transform_keys_map_13_5_function_13_5_12_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         transform_keys_map_13_5_function_13_5_12_simplify(args, info)
     }
+
 }

--- a/src/trino/transform_values_impl.rs
+++ b/src/trino/transform_values_impl.rs
@@ -54,13 +54,14 @@ fn transform_values_map_4_8_function_4_8_7_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct transform_values_map_4_8_function_4_8_7Func {
     signature: Signature,
 }
 
 impl transform_values_map_4_8_function_4_8_7Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -79,6 +80,7 @@ impl ScalarUDFImpl for transform_values_map_4_8_function_4_8_7Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         transform_values_map_4_8_function_4_8_7_return_type(arg_types)
     }
@@ -87,7 +89,12 @@ impl ScalarUDFImpl for transform_values_map_4_8_function_4_8_7Func {
         transform_values_map_4_8_function_4_8_7_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         transform_values_map_4_8_function_4_8_7_simplify(args, info)
     }
+
 }

--- a/src/trino/translate_impl.rs
+++ b/src/trino/translate_impl.rs
@@ -50,13 +50,14 @@ fn translate_varchar_varchar_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct translate_varchar_varchar_varcharFunc {
     signature: Signature,
 }
 
 impl translate_varchar_varchar_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(3, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for translate_varchar_varchar_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         translate_varchar_varchar_varchar_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for translate_varchar_varchar_varcharFunc {
         translate_varchar_varchar_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         translate_varchar_varchar_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/trim_array_impl.rs
+++ b/src/trino/trim_array_impl.rs
@@ -50,13 +50,14 @@ fn trim_array_array_3_bigint_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct trim_array_array_3_bigintFunc {
     signature: Signature,
 }
 
 impl trim_array_array_3_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for trim_array_array_3_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         trim_array_array_3_bigint_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for trim_array_array_3_bigintFunc {
         trim_array_array_3_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         trim_array_array_3_bigint_simplify(args, info)
     }
+
 }

--- a/src/trino/trim_impl.rs
+++ b/src/trino/trim_impl.rs
@@ -70,13 +70,14 @@ fn trim_varchar_codepoints_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct trim_varcharFunc {
     signature: Signature,
 }
 
 impl trim_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -95,6 +96,7 @@ impl ScalarUDFImpl for trim_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         trim_varchar_return_type(arg_types)
     }
@@ -103,9 +105,14 @@ impl ScalarUDFImpl for trim_varcharFunc {
         trim_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         trim_varchar_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -114,7 +121,7 @@ pub(super) struct trim_varchar_codepointsFunc {
 }
 
 impl trim_varchar_codepointsFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -133,6 +140,7 @@ impl ScalarUDFImpl for trim_varchar_codepointsFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         trim_varchar_codepoints_return_type(arg_types)
     }
@@ -141,7 +149,12 @@ impl ScalarUDFImpl for trim_varchar_codepointsFunc {
         trim_varchar_codepoints_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         trim_varchar_codepoints_simplify(args, info)
     }
+
 }

--- a/src/trino/truncate_impl.rs
+++ b/src/trino/truncate_impl.rs
@@ -133,13 +133,14 @@ fn truncate_real_simplify(args: Vec<Expr>, _info: &dyn SimplifyInfo) -> Result<E
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct truncate_decimal_p_s_bigintFunc {
     signature: Signature,
 }
 
 impl truncate_decimal_p_s_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -158,6 +159,7 @@ impl ScalarUDFImpl for truncate_decimal_p_s_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         truncate_decimal_p_s_bigint_return_type(arg_types)
     }
@@ -166,9 +168,14 @@ impl ScalarUDFImpl for truncate_decimal_p_s_bigintFunc {
         truncate_decimal_p_s_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         truncate_decimal_p_s_bigint_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -177,7 +184,7 @@ pub(super) struct truncate_decimal_p_sFunc {
 }
 
 impl truncate_decimal_p_sFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -196,6 +203,7 @@ impl ScalarUDFImpl for truncate_decimal_p_sFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         truncate_decimal_p_s_return_type(arg_types)
     }
@@ -204,9 +212,14 @@ impl ScalarUDFImpl for truncate_decimal_p_sFunc {
         truncate_decimal_p_s_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         truncate_decimal_p_s_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -215,7 +228,7 @@ pub(super) struct truncate_doubleFunc {
 }
 
 impl truncate_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -234,6 +247,7 @@ impl ScalarUDFImpl for truncate_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         truncate_double_return_type(arg_types)
     }
@@ -242,9 +256,14 @@ impl ScalarUDFImpl for truncate_doubleFunc {
         truncate_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         truncate_double_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -253,7 +272,7 @@ pub(super) struct truncate_realFunc {
 }
 
 impl truncate_realFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -272,6 +291,7 @@ impl ScalarUDFImpl for truncate_realFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         truncate_real_return_type(arg_types)
     }
@@ -280,7 +300,12 @@ impl ScalarUDFImpl for truncate_realFunc {
         truncate_real_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         truncate_real_simplify(args, info)
     }
+
 }

--- a/src/trino/try_impl.rs
+++ b/src/trino/try_impl.rs
@@ -47,13 +47,14 @@ fn try_1_simplify(args: Vec<Expr>, _info: &dyn SimplifyInfo) -> Result<ExprSimpl
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct try_1Func {
     signature: Signature,
 }
 
 impl try_1Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -72,6 +73,7 @@ impl ScalarUDFImpl for try_1Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         try_1_return_type(arg_types)
     }
@@ -80,7 +82,12 @@ impl ScalarUDFImpl for try_1Func {
         try_1_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         try_1_simplify(args, info)
     }
+
 }

--- a/src/trino/typeof_impl.rs
+++ b/src/trino/typeof_impl.rs
@@ -47,13 +47,14 @@ fn typeof_1_simplify(args: Vec<Expr>, _info: &dyn SimplifyInfo) -> Result<ExprSi
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct typeof_1Func {
     signature: Signature,
 }
 
 impl typeof_1Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -72,6 +73,7 @@ impl ScalarUDFImpl for typeof_1Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         typeof_1_return_type(arg_types)
     }
@@ -80,7 +82,12 @@ impl ScalarUDFImpl for typeof_1Func {
         typeof_1_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         typeof_1_simplify(args, info)
     }
+
 }

--- a/src/trino/upper_impl.rs
+++ b/src/trino/upper_impl.rs
@@ -47,13 +47,14 @@ fn upper_varchar_simplify(args: Vec<Expr>, _info: &dyn SimplifyInfo) -> Result<E
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct upper_varcharFunc {
     signature: Signature,
 }
 
 impl upper_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -72,6 +73,7 @@ impl ScalarUDFImpl for upper_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         upper_varchar_return_type(arg_types)
     }
@@ -80,7 +82,12 @@ impl ScalarUDFImpl for upper_varcharFunc {
         upper_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         upper_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/url_decode_impl.rs
+++ b/src/trino/url_decode_impl.rs
@@ -50,13 +50,14 @@ fn url_decode_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct url_decode_varcharFunc {
     signature: Signature,
 }
 
 impl url_decode_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for url_decode_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         url_decode_varchar_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for url_decode_varcharFunc {
         url_decode_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         url_decode_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/url_encode_impl.rs
+++ b/src/trino/url_encode_impl.rs
@@ -50,13 +50,14 @@ fn url_encode_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct url_encode_varcharFunc {
     signature: Signature,
 }
 
 impl url_encode_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for url_encode_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         url_encode_varchar_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for url_encode_varcharFunc {
         url_encode_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         url_encode_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/url_extract_fragment_impl.rs
+++ b/src/trino/url_extract_fragment_impl.rs
@@ -50,13 +50,14 @@ fn url_extract_fragment_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct url_extract_fragment_varcharFunc {
     signature: Signature,
 }
 
 impl url_extract_fragment_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for url_extract_fragment_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         url_extract_fragment_varchar_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for url_extract_fragment_varcharFunc {
         url_extract_fragment_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         url_extract_fragment_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/url_extract_host_impl.rs
+++ b/src/trino/url_extract_host_impl.rs
@@ -50,13 +50,14 @@ fn url_extract_host_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct url_extract_host_varcharFunc {
     signature: Signature,
 }
 
 impl url_extract_host_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for url_extract_host_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         url_extract_host_varchar_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for url_extract_host_varcharFunc {
         url_extract_host_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         url_extract_host_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/url_extract_parameter_impl.rs
+++ b/src/trino/url_extract_parameter_impl.rs
@@ -50,13 +50,14 @@ fn url_extract_parameter_varchar_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct url_extract_parameter_varchar_varcharFunc {
     signature: Signature,
 }
 
 impl url_extract_parameter_varchar_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for url_extract_parameter_varchar_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         url_extract_parameter_varchar_varchar_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for url_extract_parameter_varchar_varcharFunc {
         url_extract_parameter_varchar_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         url_extract_parameter_varchar_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/url_extract_path_impl.rs
+++ b/src/trino/url_extract_path_impl.rs
@@ -50,13 +50,14 @@ fn url_extract_path_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct url_extract_path_varcharFunc {
     signature: Signature,
 }
 
 impl url_extract_path_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for url_extract_path_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         url_extract_path_varchar_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for url_extract_path_varcharFunc {
         url_extract_path_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         url_extract_path_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/url_extract_port_impl.rs
+++ b/src/trino/url_extract_port_impl.rs
@@ -50,13 +50,14 @@ fn url_extract_port_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct url_extract_port_varcharFunc {
     signature: Signature,
 }
 
 impl url_extract_port_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for url_extract_port_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         url_extract_port_varchar_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for url_extract_port_varcharFunc {
         url_extract_port_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         url_extract_port_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/url_extract_protocol_impl.rs
+++ b/src/trino/url_extract_protocol_impl.rs
@@ -50,13 +50,14 @@ fn url_extract_protocol_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct url_extract_protocol_varcharFunc {
     signature: Signature,
 }
 
 impl url_extract_protocol_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for url_extract_protocol_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         url_extract_protocol_varchar_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for url_extract_protocol_varcharFunc {
         url_extract_protocol_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         url_extract_protocol_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/url_extract_query_impl.rs
+++ b/src/trino/url_extract_query_impl.rs
@@ -50,13 +50,14 @@ fn url_extract_query_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct url_extract_query_varcharFunc {
     signature: Signature,
 }
 
 impl url_extract_query_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for url_extract_query_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         url_extract_query_varchar_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for url_extract_query_varcharFunc {
         url_extract_query_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         url_extract_query_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/uuid_impl.rs
+++ b/src/trino/uuid_impl.rs
@@ -47,13 +47,14 @@ fn uuid_simplify(args: Vec<Expr>, _info: &dyn SimplifyInfo) -> Result<ExprSimpli
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct uuidFunc {
     signature: Signature,
 }
 
 impl uuidFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(0, Volatility::Immutable),
         }
@@ -72,6 +73,7 @@ impl ScalarUDFImpl for uuidFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         uuid_return_type(arg_types)
     }
@@ -80,7 +82,12 @@ impl ScalarUDFImpl for uuidFunc {
         uuid_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         uuid_simplify(args, info)
     }
+
 }

--- a/src/trino/value_at_quantile_impl.rs
+++ b/src/trino/value_at_quantile_impl.rs
@@ -73,13 +73,14 @@ fn value_at_quantile_tdigest_double_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct value_at_quantile_qdigest_doubleFunc {
     signature: Signature,
 }
 
 impl value_at_quantile_qdigest_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -98,6 +99,7 @@ impl ScalarUDFImpl for value_at_quantile_qdigest_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         value_at_quantile_qdigest_double_return_type(arg_types)
     }
@@ -106,9 +108,14 @@ impl ScalarUDFImpl for value_at_quantile_qdigest_doubleFunc {
         value_at_quantile_qdigest_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         value_at_quantile_qdigest_double_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -117,7 +124,7 @@ pub(super) struct value_at_quantile_tdigest_doubleFunc {
 }
 
 impl value_at_quantile_tdigest_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -136,6 +143,7 @@ impl ScalarUDFImpl for value_at_quantile_tdigest_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         value_at_quantile_tdigest_double_return_type(arg_types)
     }
@@ -144,7 +152,12 @@ impl ScalarUDFImpl for value_at_quantile_tdigest_doubleFunc {
         value_at_quantile_tdigest_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         value_at_quantile_tdigest_double_simplify(args, info)
     }
+
 }

--- a/src/trino/values_at_quantiles_impl.rs
+++ b/src/trino/values_at_quantiles_impl.rs
@@ -81,13 +81,14 @@ fn values_at_quantiles_tdigest_array_double_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct values_at_quantiles_qdigest_array_doubleFunc {
     signature: Signature,
 }
 
 impl values_at_quantiles_qdigest_array_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -106,6 +107,7 @@ impl ScalarUDFImpl for values_at_quantiles_qdigest_array_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         values_at_quantiles_qdigest_array_double_return_type(arg_types)
     }
@@ -114,9 +116,14 @@ impl ScalarUDFImpl for values_at_quantiles_qdigest_array_doubleFunc {
         values_at_quantiles_qdigest_array_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         values_at_quantiles_qdigest_array_double_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -125,7 +132,7 @@ pub(super) struct values_at_quantiles_tdigest_array_doubleFunc {
 }
 
 impl values_at_quantiles_tdigest_array_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -144,6 +151,7 @@ impl ScalarUDFImpl for values_at_quantiles_tdigest_array_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         values_at_quantiles_tdigest_array_double_return_type(arg_types)
     }
@@ -152,7 +160,12 @@ impl ScalarUDFImpl for values_at_quantiles_tdigest_array_doubleFunc {
         values_at_quantiles_tdigest_array_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         values_at_quantiles_tdigest_array_double_simplify(args, info)
     }
+
 }

--- a/src/trino/week_impl.rs
+++ b/src/trino/week_impl.rs
@@ -70,13 +70,14 @@ fn week_timestamp_p_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct week_dateFunc {
     signature: Signature,
 }
 
 impl week_dateFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -95,6 +96,7 @@ impl ScalarUDFImpl for week_dateFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         week_date_return_type(arg_types)
     }
@@ -103,9 +105,14 @@ impl ScalarUDFImpl for week_dateFunc {
         week_date_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         week_date_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -114,7 +121,7 @@ pub(super) struct week_timestamp_pFunc {
 }
 
 impl week_timestamp_pFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -133,6 +140,7 @@ impl ScalarUDFImpl for week_timestamp_pFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         week_timestamp_p_return_type(arg_types)
     }
@@ -141,7 +149,12 @@ impl ScalarUDFImpl for week_timestamp_pFunc {
         week_timestamp_p_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         week_timestamp_p_simplify(args, info)
     }
+
 }

--- a/src/trino/week_of_year_impl.rs
+++ b/src/trino/week_of_year_impl.rs
@@ -73,13 +73,14 @@ fn week_of_year_timestamp_p_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct week_of_year_dateFunc {
     signature: Signature,
 }
 
 impl week_of_year_dateFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -98,6 +99,7 @@ impl ScalarUDFImpl for week_of_year_dateFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         week_of_year_date_return_type(arg_types)
     }
@@ -106,9 +108,14 @@ impl ScalarUDFImpl for week_of_year_dateFunc {
         week_of_year_date_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         week_of_year_date_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -117,7 +124,7 @@ pub(super) struct week_of_year_timestamp_pFunc {
 }
 
 impl week_of_year_timestamp_pFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -136,6 +143,7 @@ impl ScalarUDFImpl for week_of_year_timestamp_pFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         week_of_year_timestamp_p_return_type(arg_types)
     }
@@ -144,7 +152,12 @@ impl ScalarUDFImpl for week_of_year_timestamp_pFunc {
         week_of_year_timestamp_p_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         week_of_year_timestamp_p_simplify(args, info)
     }
+
 }

--- a/src/trino/width_bucket_impl.rs
+++ b/src/trino/width_bucket_impl.rs
@@ -77,13 +77,14 @@ fn width_bucket_double_double_double_bigint_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct width_bucket_double_array_doubleFunc {
     signature: Signature,
 }
 
 impl width_bucket_double_array_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -102,6 +103,7 @@ impl ScalarUDFImpl for width_bucket_double_array_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         width_bucket_double_array_double_return_type(arg_types)
     }
@@ -110,9 +112,14 @@ impl ScalarUDFImpl for width_bucket_double_array_doubleFunc {
         width_bucket_double_array_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         width_bucket_double_array_double_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -121,7 +128,7 @@ pub(super) struct width_bucket_double_double_double_bigintFunc {
 }
 
 impl width_bucket_double_double_double_bigintFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(4, Volatility::Immutable),
         }
@@ -140,6 +147,7 @@ impl ScalarUDFImpl for width_bucket_double_double_double_bigintFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         width_bucket_double_double_double_bigint_return_type(arg_types)
     }
@@ -148,7 +156,12 @@ impl ScalarUDFImpl for width_bucket_double_double_double_bigintFunc {
         width_bucket_double_double_double_bigint_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         width_bucket_double_double_double_bigint_simplify(args, info)
     }
+
 }

--- a/src/trino/wilson_interval_lower_impl.rs
+++ b/src/trino/wilson_interval_lower_impl.rs
@@ -54,13 +54,14 @@ fn wilson_interval_lower_bigint_bigint_double_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct wilson_interval_lower_bigint_bigint_doubleFunc {
     signature: Signature,
 }
 
 impl wilson_interval_lower_bigint_bigint_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(3, Volatility::Immutable),
         }
@@ -79,6 +80,7 @@ impl ScalarUDFImpl for wilson_interval_lower_bigint_bigint_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         wilson_interval_lower_bigint_bigint_double_return_type(arg_types)
     }
@@ -87,7 +89,12 @@ impl ScalarUDFImpl for wilson_interval_lower_bigint_bigint_doubleFunc {
         wilson_interval_lower_bigint_bigint_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         wilson_interval_lower_bigint_bigint_double_simplify(args, info)
     }
+
 }

--- a/src/trino/wilson_interval_upper_impl.rs
+++ b/src/trino/wilson_interval_upper_impl.rs
@@ -54,13 +54,14 @@ fn wilson_interval_upper_bigint_bigint_double_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct wilson_interval_upper_bigint_bigint_doubleFunc {
     signature: Signature,
 }
 
 impl wilson_interval_upper_bigint_bigint_doubleFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(3, Volatility::Immutable),
         }
@@ -79,6 +80,7 @@ impl ScalarUDFImpl for wilson_interval_upper_bigint_bigint_doubleFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         wilson_interval_upper_bigint_bigint_double_return_type(arg_types)
     }
@@ -87,7 +89,12 @@ impl ScalarUDFImpl for wilson_interval_upper_bigint_bigint_doubleFunc {
         wilson_interval_upper_bigint_bigint_double_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         wilson_interval_upper_bigint_bigint_double_simplify(args, info)
     }
+
 }

--- a/src/trino/with_timezone_impl.rs
+++ b/src/trino/with_timezone_impl.rs
@@ -50,13 +50,14 @@ fn with_timezone_timestamp_p_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct with_timezone_timestamp_p_varcharFunc {
     signature: Signature,
 }
 
 impl with_timezone_timestamp_p_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for with_timezone_timestamp_p_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         with_timezone_timestamp_p_varchar_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for with_timezone_timestamp_p_varcharFunc {
         with_timezone_timestamp_p_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         with_timezone_timestamp_p_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/word_stem_impl.rs
+++ b/src/trino/word_stem_impl.rs
@@ -73,13 +73,14 @@ fn word_stem_varchar_varchar_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct word_stem_varcharFunc {
     signature: Signature,
 }
 
 impl word_stem_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -98,6 +99,7 @@ impl ScalarUDFImpl for word_stem_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         word_stem_varchar_return_type(arg_types)
     }
@@ -106,9 +108,14 @@ impl ScalarUDFImpl for word_stem_varcharFunc {
         word_stem_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         word_stem_varchar_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -117,7 +124,7 @@ pub(super) struct word_stem_varchar_varcharFunc {
 }
 
 impl word_stem_varchar_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -136,6 +143,7 @@ impl ScalarUDFImpl for word_stem_varchar_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         word_stem_varchar_varchar_return_type(arg_types)
     }
@@ -144,7 +152,12 @@ impl ScalarUDFImpl for word_stem_varchar_varcharFunc {
         word_stem_varchar_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         word_stem_varchar_varchar_simplify(args, info)
     }
+
 }

--- a/src/trino/xxhash64_impl.rs
+++ b/src/trino/xxhash64_impl.rs
@@ -50,13 +50,14 @@ fn xxhash64_varbinary_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct xxhash64_varbinaryFunc {
     signature: Signature,
 }
 
 impl xxhash64_varbinaryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -75,6 +76,7 @@ impl ScalarUDFImpl for xxhash64_varbinaryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         xxhash64_varbinary_return_type(arg_types)
     }
@@ -83,7 +85,12 @@ impl ScalarUDFImpl for xxhash64_varbinaryFunc {
         xxhash64_varbinary_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         xxhash64_varbinary_simplify(args, info)
     }
+
 }

--- a/src/trino/year_impl.rs
+++ b/src/trino/year_impl.rs
@@ -72,13 +72,14 @@ fn year_timestamp_p_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct year_dateFunc {
     signature: Signature,
 }
 
 impl year_dateFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -97,6 +98,7 @@ impl ScalarUDFImpl for year_dateFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         year_date_return_type(arg_types)
     }
@@ -105,9 +107,14 @@ impl ScalarUDFImpl for year_dateFunc {
         year_date_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         year_date_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -116,7 +123,7 @@ pub(super) struct year_intervalyeartomonthFunc {
 }
 
 impl year_intervalyeartomonthFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -135,6 +142,7 @@ impl ScalarUDFImpl for year_intervalyeartomonthFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         year_intervalyeartomonth_return_type(arg_types)
     }
@@ -143,9 +151,14 @@ impl ScalarUDFImpl for year_intervalyeartomonthFunc {
         year_intervalyeartomonth_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         year_intervalyeartomonth_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -154,7 +167,7 @@ pub(super) struct year_timestamp_pFunc {
 }
 
 impl year_timestamp_pFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -173,6 +186,7 @@ impl ScalarUDFImpl for year_timestamp_pFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         year_timestamp_p_return_type(arg_types)
     }
@@ -181,7 +195,12 @@ impl ScalarUDFImpl for year_timestamp_pFunc {
         year_timestamp_p_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         year_timestamp_p_simplify(args, info)
     }
+
 }

--- a/src/trino/year_of_week_impl.rs
+++ b/src/trino/year_of_week_impl.rs
@@ -73,13 +73,14 @@ fn year_of_week_timestamp_p_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct year_of_week_dateFunc {
     signature: Signature,
 }
 
 impl year_of_week_dateFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -98,6 +99,7 @@ impl ScalarUDFImpl for year_of_week_dateFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         year_of_week_date_return_type(arg_types)
     }
@@ -106,9 +108,14 @@ impl ScalarUDFImpl for year_of_week_dateFunc {
         year_of_week_date_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         year_of_week_date_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -117,7 +124,7 @@ pub(super) struct year_of_week_timestamp_pFunc {
 }
 
 impl year_of_week_timestamp_pFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -136,6 +143,7 @@ impl ScalarUDFImpl for year_of_week_timestamp_pFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         year_of_week_timestamp_p_return_type(arg_types)
     }
@@ -144,7 +152,12 @@ impl ScalarUDFImpl for year_of_week_timestamp_pFunc {
         year_of_week_timestamp_p_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         year_of_week_timestamp_p_simplify(args, info)
     }
+
 }

--- a/src/trino/yow_impl.rs
+++ b/src/trino/yow_impl.rs
@@ -70,13 +70,14 @@ fn yow_timestamp_p_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct yow_dateFunc {
     signature: Signature,
 }
 
 impl yow_dateFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -95,6 +96,7 @@ impl ScalarUDFImpl for yow_dateFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         yow_date_return_type(arg_types)
     }
@@ -103,9 +105,14 @@ impl ScalarUDFImpl for yow_dateFunc {
         yow_date_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         yow_date_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -114,7 +121,7 @@ pub(super) struct yow_timestamp_pFunc {
 }
 
 impl yow_timestamp_pFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -133,6 +140,7 @@ impl ScalarUDFImpl for yow_timestamp_pFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         yow_timestamp_p_return_type(arg_types)
     }
@@ -141,7 +149,12 @@ impl ScalarUDFImpl for yow_timestamp_pFunc {
         yow_timestamp_p_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         yow_timestamp_p_simplify(args, info)
     }
+
 }

--- a/src/trino/zip_impl.rs
+++ b/src/trino/zip_impl.rs
@@ -127,13 +127,14 @@ fn zip_array_14_array_15_array_16_array_17_array_18_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct zip_array_14_array_15Func {
     signature: Signature,
 }
 
 impl zip_array_14_array_15Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(2, Volatility::Immutable),
         }
@@ -152,6 +153,7 @@ impl ScalarUDFImpl for zip_array_14_array_15Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         zip_array_14_array_15_return_type(arg_types)
     }
@@ -160,9 +162,14 @@ impl ScalarUDFImpl for zip_array_14_array_15Func {
         zip_array_14_array_15_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         zip_array_14_array_15_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -171,7 +178,7 @@ pub(super) struct zip_array_14_array_15_array_16Func {
 }
 
 impl zip_array_14_array_15_array_16Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(3, Volatility::Immutable),
         }
@@ -190,6 +197,7 @@ impl ScalarUDFImpl for zip_array_14_array_15_array_16Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         zip_array_14_array_15_array_16_return_type(arg_types)
     }
@@ -198,9 +206,14 @@ impl ScalarUDFImpl for zip_array_14_array_15_array_16Func {
         zip_array_14_array_15_array_16_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         zip_array_14_array_15_array_16_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -209,7 +222,7 @@ pub(super) struct zip_array_14_array_15_array_16_array_17Func {
 }
 
 impl zip_array_14_array_15_array_16_array_17Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(4, Volatility::Immutable),
         }
@@ -228,6 +241,7 @@ impl ScalarUDFImpl for zip_array_14_array_15_array_16_array_17Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         zip_array_14_array_15_array_16_array_17_return_type(arg_types)
     }
@@ -236,9 +250,14 @@ impl ScalarUDFImpl for zip_array_14_array_15_array_16_array_17Func {
         zip_array_14_array_15_array_16_array_17_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         zip_array_14_array_15_array_16_array_17_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -247,7 +266,7 @@ pub(super) struct zip_array_14_array_15_array_16_array_17_array_18Func {
 }
 
 impl zip_array_14_array_15_array_16_array_17_array_18Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(5, Volatility::Immutable),
         }
@@ -266,6 +285,7 @@ impl ScalarUDFImpl for zip_array_14_array_15_array_16_array_17_array_18Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         zip_array_14_array_15_array_16_array_17_array_18_return_type(arg_types)
     }
@@ -274,7 +294,12 @@ impl ScalarUDFImpl for zip_array_14_array_15_array_16_array_17_array_18Func {
         zip_array_14_array_15_array_16_array_17_array_18_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         zip_array_14_array_15_array_16_array_17_array_18_simplify(args, info)
     }
+
 }

--- a/src/trino/zip_with_impl.rs
+++ b/src/trino/zip_with_impl.rs
@@ -54,13 +54,14 @@ fn zip_with_array_1_array_11_function_1_11_9_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct zip_with_array_1_array_11_function_1_11_9Func {
     signature: Signature,
 }
 
 impl zip_with_array_1_array_11_function_1_11_9Func {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(3, Volatility::Immutable),
         }
@@ -79,6 +80,7 @@ impl ScalarUDFImpl for zip_with_array_1_array_11_function_1_11_9Func {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         zip_with_array_1_array_11_function_1_11_9_return_type(arg_types)
     }
@@ -87,7 +89,12 @@ impl ScalarUDFImpl for zip_with_array_1_array_11_function_1_11_9Func {
         zip_with_array_1_array_11_function_1_11_9_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         zip_with_array_1_array_11_function_1_11_9_simplify(args, info)
     }
+
 }


### PR DESCRIPTION
This should be only whitespace and formatting, except for the `length` UDF where we have previously dropped `length(array)`, since it is `cardinality(array)`.

The output from `make-functions` and what we have currently checked in have somehow diverged, so this PR is for the purpose of making more clear what the upcoming substantive change will be. 