### PR TITLE
Re-generate UDFs affected by signature::variadic_equal disappearance in DataFusion

### DIFF
--- a/src/trino/coalesce_impl.rs
+++ b/src/trino/coalesce_impl.rs
@@ -56,7 +56,7 @@ pub(super) struct coalesce_1Func {
 impl coalesce_1Func {
     pub fn new() -> Self {        
         Self {
-            signature: Signature::variadic_equal(Volatility::Immutable),
+            signature: Signature::variadic_any(Volatility::Immutable),
         }
     }
 }

--- a/src/trino/concat_impl.rs
+++ b/src/trino/concat_impl.rs
@@ -218,7 +218,7 @@ pub(super) struct concat_array_3Func {
 impl concat_array_3Func {
     pub fn new() -> Self {        
         Self {
-            signature: Signature::variadic_equal(Volatility::Immutable),
+            signature: Signature::variadic_any(Volatility::Immutable),
         }
     }
 }
@@ -350,7 +350,7 @@ pub(super) struct concat_varcharFunc {
 impl concat_varcharFunc {
     pub fn new() -> Self {        
         Self {
-            signature: Signature::variadic_equal(Volatility::Immutable),
+            signature: Signature::variadic_any(Volatility::Immutable),
         }
     }
 }
@@ -394,7 +394,7 @@ pub(super) struct concat_varbinaryFunc {
 impl concat_varbinaryFunc {
     pub fn new() -> Self {        
         Self {
-            signature: Signature::variadic_equal(Volatility::Immutable),
+            signature: Signature::variadic_any(Volatility::Immutable),
         }
     }
 }

--- a/src/trino/concat_ws_impl.rs
+++ b/src/trino/concat_ws_impl.rs
@@ -126,7 +126,7 @@ pub(super) struct concat_ws_varcharFunc {
 impl concat_ws_varcharFunc {
     pub fn new() -> Self {        
         Self {
-            signature: Signature::variadic_equal(Volatility::Immutable),
+            signature: Signature::variadic_any(Volatility::Immutable),
         }
     }
 }

--- a/src/trino/greatest_impl.rs
+++ b/src/trino/greatest_impl.rs
@@ -63,7 +63,7 @@ pub(super) struct greatest_3Func {
 impl greatest_3Func {
     pub fn new() -> Self {        
         Self {
-            signature: Signature::variadic_equal(Volatility::Immutable),
+            signature: Signature::variadic_any(Volatility::Immutable),
         }
     }
 }

--- a/src/trino/least_impl.rs
+++ b/src/trino/least_impl.rs
@@ -63,7 +63,7 @@ pub(super) struct least_3Func {
 impl least_3Func {
     pub fn new() -> Self {        
         Self {
-            signature: Signature::variadic_equal(Volatility::Immutable),
+            signature: Signature::variadic_any(Volatility::Immutable),
         }
     }
 }

--- a/src/trino/length_impl.rs
+++ b/src/trino/length_impl.rs
@@ -73,13 +73,14 @@ fn length_varbinary_simplify(
 // Do *NOT* edit below this line: all changes will be overwritten
 // when template is regenerated!
 
+
 #[derive(Debug)]
 pub(super) struct length_varcharFunc {
     signature: Signature,
 }
 
 impl length_varcharFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -98,6 +99,7 @@ impl ScalarUDFImpl for length_varcharFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         length_varchar_return_type(arg_types)
     }
@@ -106,9 +108,14 @@ impl ScalarUDFImpl for length_varcharFunc {
         length_varchar_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         length_varchar_simplify(args, info)
     }
+
 }
 
 #[derive(Debug)]
@@ -117,7 +124,7 @@ pub(super) struct length_varbinaryFunc {
 }
 
 impl length_varbinaryFunc {
-    pub fn new() -> Self {
+    pub fn new() -> Self {        
         Self {
             signature: Signature::any(1, Volatility::Immutable),
         }
@@ -136,6 +143,7 @@ impl ScalarUDFImpl for length_varbinaryFunc {
         &self.signature
     }
 
+
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
         length_varbinary_return_type(arg_types)
     }
@@ -144,7 +152,12 @@ impl ScalarUDFImpl for length_varbinaryFunc {
         length_varbinary_invoke(args)
     }
 
-    fn simplify(&self, args: Vec<Expr>, info: &dyn SimplifyInfo) -> Result<ExprSimplifyResult> {
+    fn simplify(
+        &self,
+        args: Vec<Expr>,
+        info: &dyn SimplifyInfo,
+    ) -> Result<ExprSimplifyResult> {
         length_varbinary_simplify(args, info)
     }
+
 }

--- a/src/trino/map_concat_impl.rs
+++ b/src/trino/map_concat_impl.rs
@@ -59,7 +59,7 @@ pub(super) struct map_concat_map_4_5Func {
 impl map_concat_map_4_5Func {
     pub fn new() -> Self {        
         Self {
-            signature: Signature::variadic_equal(Volatility::Immutable),
+            signature: Signature::variadic_any(Volatility::Immutable),
         }
     }
 }


### PR DESCRIPTION
These are re-generated UDFs adjusting to the disappearance of DataFusion's `signature::TypeSignature::VariadicEqual` in https://github.com/apache/datafusion/pull/10439

In DataFusion's, this was replaced with the new `signature::TypeSignature::UserDefined`, which comes with a new method `ScalarUDFImpl::coerce_types` (to be user-implemented) that DF calls to preprocess actual arguments before passing them to the `invoke` method. 
This is not something that is suitable to our more statically-checked setting, so this PR replaces  `VariadicEqual` with `VariadicAny`.  It's a worse approximation to SDF function signatures, but that's only important for "documentation"-like purposes; SDF typechecking and execution are not affected. 