### PR TITLE
Re-generate UDFs affected by signature::variadic_equal disappearance in DataFusion

### DIFF
--- a/src/trino/coalesce_impl.rs
+++ b/src/trino/coalesce_impl.rs
@@ -55,7 +55,7 @@ pub(super) struct coalesce_1Func {
 impl coalesce_1Func {
     pub fn new() -> Self {
         Self {
-            signature: Signature::variadic_equal(Volatility::Immutable),
+            signature: Signature::variadic_any(Volatility::Immutable),
         }
     }
 }

--- a/src/trino/concat_impl.rs
+++ b/src/trino/concat_impl.rs
@@ -211,7 +211,7 @@ pub(super) struct concat_array_3Func {
 impl concat_array_3Func {
     pub fn new() -> Self {
         Self {
-            signature: Signature::variadic_equal(Volatility::Immutable),
+            signature: Signature::variadic_any(Volatility::Immutable),
         }
     }
 }
@@ -325,7 +325,7 @@ pub(super) struct concat_varcharFunc {
 impl concat_varcharFunc {
     pub fn new() -> Self {
         Self {
-            signature: Signature::variadic_equal(Volatility::Immutable),
+            signature: Signature::variadic_any(Volatility::Immutable),
         }
     }
 }
@@ -363,7 +363,7 @@ pub(super) struct concat_varbinaryFunc {
 impl concat_varbinaryFunc {
     pub fn new() -> Self {
         Self {
-            signature: Signature::variadic_equal(Volatility::Immutable),
+            signature: Signature::variadic_any(Volatility::Immutable),
         }
     }
 }

--- a/src/trino/concat_ws_impl.rs
+++ b/src/trino/concat_ws_impl.rs
@@ -119,7 +119,7 @@ pub(super) struct concat_ws_varcharFunc {
 impl concat_ws_varcharFunc {
     pub fn new() -> Self {
         Self {
-            signature: Signature::variadic_equal(Volatility::Immutable),
+            signature: Signature::variadic_any(Volatility::Immutable),
         }
     }
 }

--- a/src/trino/greatest_impl.rs
+++ b/src/trino/greatest_impl.rs
@@ -62,7 +62,7 @@ pub(super) struct greatest_3Func {
 impl greatest_3Func {
     pub fn new() -> Self {
         Self {
-            signature: Signature::variadic_equal(Volatility::Immutable),
+            signature: Signature::variadic_any(Volatility::Immutable),
         }
     }
 }

--- a/src/trino/least_impl.rs
+++ b/src/trino/least_impl.rs
@@ -62,7 +62,7 @@ pub(super) struct least_3Func {
 impl least_3Func {
     pub fn new() -> Self {
         Self {
-            signature: Signature::variadic_equal(Volatility::Immutable),
+            signature: Signature::variadic_any(Volatility::Immutable),
         }
     }
 }

--- a/src/trino/map_concat_impl.rs
+++ b/src/trino/map_concat_impl.rs
@@ -58,7 +58,7 @@ pub(super) struct map_concat_map_4_5Func {
 impl map_concat_map_4_5Func {
     pub fn new() -> Self {
         Self {
-            signature: Signature::variadic_equal(Volatility::Immutable),
+            signature: Signature::variadic_any(Volatility::Immutable),
         }
     }
 }


### PR DESCRIPTION
These are the re-generated UDFs adjusting to the disappearance of DataFusion's `signature::TypeSignature::VariadicEqual` in https://github.com/apache/datafusion/pull/10439

In DataFusion, this was replaced with the new `signature::TypeSignature::UserDefined`, which comes with a new method `ScalarUDFImpl::coerce_types` (to be user-implemented) that DF calls to preprocess actual arguments before passing them to the `invoke` method. 
This is not something that is suitable to our more statically-checked setting, so this PR replaces  `VariadicEqual` with `VariadicAny`.  It's a worse approximation to SDF function signatures, but that's only important for "documentation"-like purposes; SDF typechecking and execution are not affected. 